### PR TITLE
feat : Customer 회원 가입 기능 구현

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/YunmarketApplication.java
+++ b/src/main/java/com/yjjjwww/yunmarket/YunmarketApplication.java
@@ -2,10 +2,8 @@ package com.yjjjwww.yunmarket;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class YunmarketApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/yjjjwww/yunmarket/YunmarketApplication.java
+++ b/src/main/java/com/yjjjwww/yunmarket/YunmarketApplication.java
@@ -2,12 +2,14 @@ package com.yjjjwww.yunmarket;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class YunmarketApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(YunmarketApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(YunmarketApplication.class, args);
+  }
 
 }

--- a/src/main/java/com/yjjjwww/yunmarket/config/JpaAuditingConfiguration.java
+++ b/src/main/java/com/yjjjwww/yunmarket/config/JpaAuditingConfiguration.java
@@ -1,0 +1,10 @@
+package com.yjjjwww.yunmarket.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+
+}

--- a/src/main/java/com/yjjjwww/yunmarket/config/SecurityConfig.java
+++ b/src/main/java/com/yjjjwww/yunmarket/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.yjjjwww.yunmarket.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  @Bean
+  public PasswordEncoder getPasswordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.httpBasic().disable()
+        .csrf().disable()
+        .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        .and()
+        .authorizeRequests()
+        .antMatchers("/**/signUp", "/**/signIn").permitAll();
+
+    return http.build();
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/customer/controller/CustomerController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/controller/CustomerController.java
@@ -1,0 +1,23 @@
+package com.yjjjwww.yunmarket.customer.controller;
+
+import com.yjjjwww.yunmarket.customer.model.CustomerSignUpForm;
+import com.yjjjwww.yunmarket.customer.service.CustomerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/customer")
+public class CustomerController {
+
+  private final CustomerService customerService;
+
+  @PostMapping("/signUp")
+  public ResponseEntity<String> signUp(@RequestBody CustomerSignUpForm customerSignUpForm) {
+    return ResponseEntity.ok(customerService.signUp(customerSignUpForm));
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/customer/controller/CustomerController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/controller/CustomerController.java
@@ -15,9 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class CustomerController {
 
   private final CustomerService customerService;
+  private static final String SIGNUP_SUCCESS = "회원가입 성공";
 
   @PostMapping("/signUp")
   public ResponseEntity<String> signUp(@RequestBody CustomerSignUpForm customerSignUpForm) {
-    return ResponseEntity.ok(customerService.signUp(customerSignUpForm));
+    customerService.signUp(customerSignUpForm.toServiceForm());
+    return ResponseEntity.ok(SIGNUP_SUCCESS);
   }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/customer/entity/Customer.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/entity/Customer.java
@@ -1,0 +1,35 @@
+package com.yjjjwww.yunmarket.customer.entity;
+
+import com.yjjjwww.yunmarket.entity.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+@Entity
+public class Customer extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  Long id;
+
+  @Column(unique = true)
+  String email;
+
+  String password;
+  String phone;
+  String address;
+  Integer point;
+  boolean deletedYn;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/customer/entity/Customer.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/entity/Customer.java
@@ -22,7 +22,7 @@ public class Customer extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  Long id;
+  private Long id;
 
   @Column(unique = true)
   String email;

--- a/src/main/java/com/yjjjwww/yunmarket/customer/model/CustomerSignUpForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/model/CustomerSignUpForm.java
@@ -1,8 +1,10 @@
 package com.yjjjwww.yunmarket.customer.model;
 
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class CustomerSignUpForm {
 
   private String email;

--- a/src/main/java/com/yjjjwww/yunmarket/customer/model/CustomerSignUpForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/model/CustomerSignUpForm.java
@@ -1,0 +1,12 @@
+package com.yjjjwww.yunmarket.customer.model;
+
+import lombok.Data;
+
+@Data
+public class CustomerSignUpForm {
+
+  private String email;
+  private String password;
+  private String phone;
+  private String address;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/customer/model/CustomerSignUpServiceForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/model/CustomerSignUpServiceForm.java
@@ -9,19 +9,10 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CustomerSignUpForm {
+public class CustomerSignUpServiceForm {
 
   private String email;
   private String password;
   private String phone;
   private String address;
-
-  public CustomerSignUpServiceForm toServiceForm() {
-    return CustomerSignUpServiceForm.builder()
-        .email(email)
-        .password(password)
-        .phone(phone)
-        .address(address)
-        .build();
-  }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/repository/CustomerRepository.java
@@ -1,0 +1,10 @@
+package com.yjjjwww.yunmarket.customer.repository;
+
+import com.yjjjwww.yunmarket.customer.entity.Customer;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+
+  Optional<Customer> findByEmail(String email);
+}

--- a/src/main/java/com/yjjjwww/yunmarket/customer/service/CustomerService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/service/CustomerService.java
@@ -1,11 +1,11 @@
 package com.yjjjwww.yunmarket.customer.service;
 
-import com.yjjjwww.yunmarket.customer.model.CustomerSignUpForm;
+import com.yjjjwww.yunmarket.customer.model.CustomerSignUpServiceForm;
 
 public interface CustomerService {
 
   /**
    * Customer 회원가입
    */
-  String signUp(CustomerSignUpForm customerSignUpForm);
+  void signUp(CustomerSignUpServiceForm customerSignUpServiceForm);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/customer/service/CustomerService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/service/CustomerService.java
@@ -1,0 +1,11 @@
+package com.yjjjwww.yunmarket.customer.service;
+
+import com.yjjjwww.yunmarket.customer.model.CustomerSignUpForm;
+
+public interface CustomerService {
+
+  /**
+   * Customer 회원가입
+   */
+  String signUp(CustomerSignUpForm customerSignUpForm);
+}

--- a/src/main/java/com/yjjjwww/yunmarket/customer/service/CustomerServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/service/CustomerServiceImpl.java
@@ -1,0 +1,85 @@
+package com.yjjjwww.yunmarket.customer.service;
+
+import com.yjjjwww.yunmarket.customer.entity.Customer;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.customer.model.CustomerSignUpForm;
+import com.yjjjwww.yunmarket.customer.repository.CustomerRepository;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomerServiceImpl implements CustomerService {
+
+  private final CustomerRepository customerRepository;
+
+  private static final String SIGNUP_SUCCESS = "회원가입 성공";
+
+  @Override
+  public String signUp(CustomerSignUpForm customerSignUpForm) {
+    Optional<Customer> optionalCustomer =
+        customerRepository.findByEmail(customerSignUpForm.getEmail());
+    if (optionalCustomer.isPresent()) {
+      throw (new CustomException(ErrorCode.ALREADY_SIGNUP_EMAIL));
+    }
+
+    if (!isValidPassword(customerSignUpForm.getPassword())) {
+      throw new CustomException(ErrorCode.INVALID_PASSWORD);
+    }
+
+    if (!isValidPhone(customerSignUpForm.getPhone())) {
+      throw new CustomException(ErrorCode.INVALID_PHONE);
+    }
+
+    String encPassword = BCrypt.hashpw(customerSignUpForm.getPassword(), BCrypt.gensalt());
+
+    Customer customer = Customer.builder()
+        .email(customerSignUpForm.getEmail())
+        .password(encPassword)
+        .phone(customerSignUpForm.getPhone())
+        .address(customerSignUpForm.getAddress())
+        .point(0)
+        .deletedYn(false)
+        .build();
+
+    customerRepository.save(customer);
+
+    return SIGNUP_SUCCESS;
+  }
+
+  /**
+   * 핸드폰 번호 형식 검사
+   */
+  private static boolean isValidPhone(String phone) {
+    if (phone.length() > 11 || phone.length() < 5) {
+      return false;
+    }
+    boolean err = false;
+    String regex = "^[0-9]*$";
+    Pattern p = Pattern.compile(regex);
+    Matcher m = p.matcher(phone);
+    if (m.matches()) {
+      err = true;
+    }
+    return err;
+  }
+
+  /**
+   * 비밀번호 형식 검사(최소 8자리에 숫자, 문자, 특수문자 각각 1개 이상 포함)
+   */
+  private static boolean isValidPassword(String password) {
+    boolean err = false;
+    String regex = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,}$";
+    Pattern p = Pattern.compile(regex);
+    Matcher m = p.matcher(password);
+    if (m.matches()) {
+      err = true;
+    }
+    return err;
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/entity/BaseEntity.java
+++ b/src/main/java/com/yjjjwww/yunmarket/entity/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.yjjjwww.yunmarket.entity;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+public class BaseEntity {
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdDate;
+
+  @LastModifiedDate
+  private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/exception/CustomException.java
+++ b/src/main/java/com/yjjjwww/yunmarket/exception/CustomException.java
@@ -1,0 +1,30 @@
+package com.yjjjwww.yunmarket.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+  private final int status;
+
+  public CustomException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+    this.status = errorCode.getHttpStatus().value();
+  }
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class CustomExceptionResponse {
+
+    private int status;
+    private String code;
+    private String message;
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/yjjjwww/yunmarket/exception/CustomExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.yjjjwww.yunmarket.exception;
+
+import com.yjjjwww.yunmarket.exception.CustomException.CustomExceptionResponse;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<CustomExceptionResponse> exceptionHandler
+      (HttpServletRequest req, final CustomException e) {
+    return ResponseEntity.status(e.getStatus())
+        .body(CustomExceptionResponse.builder()
+            .message(e.getMessage())
+            .code(e.getErrorCode().name())
+            .status(e.getStatus())
+            .build());
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
+++ b/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.yjjjwww.yunmarket.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorCode {
+  INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자리에 숫자, 문자, 특수문자 각각 1개 이상 포함해야 합니다."),
+  INVALID_PHONE(HttpStatus.BAD_REQUEST, "핸드폰 번호 형식을 확인해주세요."),
+  ALREADY_SIGNUP_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다.");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
-
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/yunmarket?characterEncoding=UTF-8&serverTimezone=UTC
+spring.datasource.username=root
+spring.datasource.password=yjw202020@
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.format_sql=true

--- a/src/test/java/com/yjjjwww/yunmarket/YunmarketApplicationTests.java
+++ b/src/test/java/com/yjjjwww/yunmarket/YunmarketApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class YunmarketApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+  @Test
+  void contextLoads() {
+  }
 
 }

--- a/src/test/java/com/yjjjwww/yunmarket/customer/controller/CustomerControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/customer/controller/CustomerControllerTest.java
@@ -1,7 +1,7 @@
 package com.yjjjwww.yunmarket.customer.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -44,7 +44,6 @@ class CustomerControllerTest {
         .address("대한민국 경기도 안양시")
         .build();
 
-    given(customerService.signUp(form)).willReturn("회원가입 성공");
     //when
     //then
     mockMvc.perform(post("/customer/signUp")
@@ -64,8 +63,9 @@ class CustomerControllerTest {
         .address("대한민국 경기도 안양시")
         .build();
 
-    given(customerService.signUp(form)).willThrow(
-        new CustomException(ErrorCode.ALREADY_SIGNUP_EMAIL));
+    doThrow(new CustomException(ErrorCode.ALREADY_SIGNUP_EMAIL))
+        .when(customerService)
+        .signUp(form.toServiceForm());
     //when
     //then
     ResultActions result = mockMvc.perform(post("/customer/signUp")
@@ -90,8 +90,9 @@ class CustomerControllerTest {
         .address("대한민국 경기도 안양시")
         .build();
 
-    given(customerService.signUp(form)).willThrow(
-        new CustomException(ErrorCode.INVALID_PASSWORD));
+    doThrow(new CustomException(ErrorCode.INVALID_PASSWORD))
+        .when(customerService)
+        .signUp(form.toServiceForm());
     //when
     //then
     ResultActions result = mockMvc.perform(post("/customer/signUp")
@@ -116,8 +117,9 @@ class CustomerControllerTest {
         .address("대한민국 경기도 안양시")
         .build();
 
-    given(customerService.signUp(form)).willThrow(
-        new CustomException(ErrorCode.INVALID_PHONE));
+    doThrow(new CustomException(ErrorCode.INVALID_PHONE))
+        .when(customerService)
+        .signUp(form.toServiceForm());
     //when
     //then
     ResultActions result = mockMvc.perform(post("/customer/signUp")

--- a/src/test/java/com/yjjjwww/yunmarket/customer/controller/CustomerControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/customer/controller/CustomerControllerTest.java
@@ -1,0 +1,134 @@
+package com.yjjjwww.yunmarket.customer.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yjjjwww.yunmarket.customer.model.CustomerSignUpForm;
+import com.yjjjwww.yunmarket.customer.service.CustomerService;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CustomerControllerTest {
+
+  @MockBean
+  private CustomerService customerService;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  void customerSignUpSuccess() throws Exception {
+    //given
+    CustomerSignUpForm form = CustomerSignUpForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234@")
+        .phone("01011112222")
+        .address("대한민국 경기도 안양시")
+        .build();
+
+    given(customerService.signUp(form)).willReturn("회원가입 성공");
+    //when
+    //then
+    mockMvc.perform(post("/customer/signUp")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  void customerSignUpFail_ALREADY_SIGNUP_EMAIL() throws Exception {
+    //given
+    CustomerSignUpForm form = CustomerSignUpForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234@")
+        .phone("01011112222")
+        .address("대한민국 경기도 안양시")
+        .build();
+
+    given(customerService.signUp(form)).willThrow(
+        new CustomException(ErrorCode.ALREADY_SIGNUP_EMAIL));
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/customer/signUp")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("ALREADY_SIGNUP_EMAIL", code);
+  }
+
+  @Test
+  void customerSignUpFail_INVALID_PASSWORD() throws Exception {
+    //given
+    CustomerSignUpForm form = CustomerSignUpForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234")
+        .phone("01011112222")
+        .address("대한민국 경기도 안양시")
+        .build();
+
+    given(customerService.signUp(form)).willThrow(
+        new CustomException(ErrorCode.INVALID_PASSWORD));
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/customer/signUp")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("INVALID_PASSWORD", code);
+  }
+
+  @Test
+  void customerSignUpFail_INVALID_PHONE() throws Exception {
+    //given
+    CustomerSignUpForm form = CustomerSignUpForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234")
+        .phone("01011112222124352353462436")
+        .address("대한민국 경기도 안양시")
+        .build();
+
+    given(customerService.signUp(form)).willThrow(
+        new CustomException(ErrorCode.INVALID_PHONE));
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/customer/signUp")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("INVALID_PHONE", code);
+  }
+}

--- a/src/test/java/com/yjjjwww/yunmarket/customer/service/CustomerServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/customer/service/CustomerServiceImplTest.java
@@ -2,8 +2,11 @@ package com.yjjjwww.yunmarket.customer.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.yjjjwww.yunmarket.customer.entity.Customer;
 import com.yjjjwww.yunmarket.customer.model.CustomerSignUpForm;
@@ -19,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class CustomerServiceImplTest {
+
   @Mock
   private CustomerRepository customerRepository;
 
@@ -36,10 +40,10 @@ class CustomerServiceImplTest {
         .build();
 
     //when
-    String result = customerService.signUp(form);
+    customerService.signUp(form.toServiceForm());
 
     //then
-    assertEquals("회원가입 성공", result);
+    verify(customerRepository, times(1)).save(any(Customer.class));
   }
 
   @Test
@@ -57,7 +61,7 @@ class CustomerServiceImplTest {
 
     //when
     CustomException exception = assertThrows(CustomException.class,
-        () -> customerService.signUp(form));
+        () -> customerService.signUp(form.toServiceForm()));
 
     //then
     assertEquals(ErrorCode.ALREADY_SIGNUP_EMAIL, exception.getErrorCode());
@@ -75,7 +79,7 @@ class CustomerServiceImplTest {
 
     //when
     CustomException exception = assertThrows(CustomException.class,
-        () -> customerService.signUp(form));
+        () -> customerService.signUp(form.toServiceForm()));
 
     //then
     assertEquals(ErrorCode.INVALID_PASSWORD, exception.getErrorCode());
@@ -93,7 +97,7 @@ class CustomerServiceImplTest {
 
     //when
     CustomException exception = assertThrows(CustomException.class,
-        () -> customerService.signUp(form));
+        () -> customerService.signUp(form.toServiceForm()));
 
     //then
     assertEquals(ErrorCode.INVALID_PHONE, exception.getErrorCode());

--- a/src/test/java/com/yjjjwww/yunmarket/customer/service/CustomerServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/customer/service/CustomerServiceImplTest.java
@@ -1,0 +1,101 @@
+package com.yjjjwww.yunmarket.customer.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import com.yjjjwww.yunmarket.customer.entity.Customer;
+import com.yjjjwww.yunmarket.customer.model.CustomerSignUpForm;
+import com.yjjjwww.yunmarket.customer.repository.CustomerRepository;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CustomerServiceImplTest {
+  @Mock
+  private CustomerRepository customerRepository;
+
+  @InjectMocks
+  private CustomerServiceImpl customerService;
+
+  @Test
+  void customerSignUpSuccess() {
+    //given
+    CustomerSignUpForm form = CustomerSignUpForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234@")
+        .phone("01011112222")
+        .address("대한민국 경기도 안양시")
+        .build();
+
+    //when
+    String result = customerService.signUp(form);
+
+    //then
+    assertEquals("회원가입 성공", result);
+  }
+
+  @Test
+  void customerSignUpFail_ALREADY_SIGNUP_EMAIL() {
+    //given
+    CustomerSignUpForm form = CustomerSignUpForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234@")
+        .phone("01011112222")
+        .address("대한민국 경기도 안양시")
+        .build();
+
+    given(customerRepository.findByEmail(anyString()))
+        .willReturn(Optional.ofNullable(Customer.builder().build()));
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> customerService.signUp(form));
+
+    //then
+    assertEquals(ErrorCode.ALREADY_SIGNUP_EMAIL, exception.getErrorCode());
+  }
+
+  @Test
+  void customerSignUpFail_INVALID_PASSWORD() {
+    //given
+    CustomerSignUpForm form = CustomerSignUpForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234")
+        .phone("01011112222")
+        .address("대한민국 경기도 안양시")
+        .build();
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> customerService.signUp(form));
+
+    //then
+    assertEquals(ErrorCode.INVALID_PASSWORD, exception.getErrorCode());
+  }
+
+  @Test
+  void customerSignUpFail_INVALID_PHONE() {
+    //given
+    CustomerSignUpForm form = CustomerSignUpForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234@")
+        .phone("010111122221231242151353253241342141")
+        .address("대한민국 경기도 안양시")
+        .build();
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> customerService.signUp(form));
+
+    //then
+    assertEquals(ErrorCode.INVALID_PHONE, exception.getErrorCode());
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- Customer 엔티티 설정했습니다. Customer 데이터베이스에는 이메일, 비밀번호, 연락처, 적립금, 삭제여부를 저장합니다.
- 회원가입시 이미 등록된 이메일이 있는지 확인합니다.
- 회원가입시 비밀번호 유효성 검사, 연락처 형식 유효성 검사를 합니다.
- Customer 비밀번호는 암호화해서 데이터베이스에 저장합니다.
- 기본 적립금은 0원으로 저장됩니다.
- postman으로 API 테스트 완료했고, 테스트 코드로 성공할 경우와 Custom Error가 발생할 경우 올바른 응답이 나오는지 확인했습니다.

**TO-BE**
- Seller 회원 가입
- Customer, Seller 로그인

### 테스트
- [x] 테스트 코드
- [x] API 테스트 