### PR TITLE
Feature/seller signup

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/seller/controller/SellerController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/seller/controller/SellerController.java
@@ -1,0 +1,25 @@
+package com.yjjjwww.yunmarket.seller.controller;
+
+import com.yjjjwww.yunmarket.seller.model.SellerSignUpForm;
+import com.yjjjwww.yunmarket.seller.service.SellerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/seller")
+public class SellerController {
+
+  private final SellerService sellerService;
+  private static final String SIGNUP_SUCCESS = "회원가입 성공";
+
+  @PostMapping("/signUp")
+  public ResponseEntity<String> signUp(@RequestBody SellerSignUpForm sellerSignUpForm) {
+    sellerService.signUp(sellerSignUpForm.toServiceForm());
+    return ResponseEntity.ok(SIGNUP_SUCCESS);
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/seller/entity/Seller.java
+++ b/src/main/java/com/yjjjwww/yunmarket/seller/entity/Seller.java
@@ -1,0 +1,33 @@
+package com.yjjjwww.yunmarket.seller.entity;
+
+import com.yjjjwww.yunmarket.entity.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+@Entity
+public class Seller extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(unique = true)
+  String email;
+
+  String password;
+  String phone;
+  boolean deletedYn;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/seller/model/SellerSignUpForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/seller/model/SellerSignUpForm.java
@@ -1,0 +1,25 @@
+package com.yjjjwww.yunmarket.seller.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SellerSignUpForm {
+
+  private String email;
+  private String password;
+  private String phone;
+
+  public SellerSignUpServiceForm toServiceForm() {
+    return SellerSignUpServiceForm.builder()
+        .email(email)
+        .password(password)
+        .phone(phone)
+        .build();
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/seller/model/SellerSignUpServiceForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/seller/model/SellerSignUpServiceForm.java
@@ -1,0 +1,17 @@
+package com.yjjjwww.yunmarket.seller.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SellerSignUpServiceForm {
+
+  private String email;
+  private String password;
+  private String phone;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/seller/repository/SellerRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/seller/repository/SellerRepository.java
@@ -1,0 +1,10 @@
+package com.yjjjwww.yunmarket.seller.repository;
+
+import com.yjjjwww.yunmarket.seller.entity.Seller;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SellerRepository extends JpaRepository<Seller, Long> {
+
+  Optional<Seller> findByEmail(String email);
+}

--- a/src/main/java/com/yjjjwww/yunmarket/seller/service/SellerService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/seller/service/SellerService.java
@@ -1,0 +1,11 @@
+package com.yjjjwww.yunmarket.seller.service;
+
+import com.yjjjwww.yunmarket.seller.model.SellerSignUpServiceForm;
+
+public interface SellerService {
+
+  /**
+   * Seller 회원가입
+   */
+  void signUp(SellerSignUpServiceForm sellerSignUpServiceForm);
+}

--- a/src/main/java/com/yjjjwww/yunmarket/seller/service/SellerServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/seller/service/SellerServiceImpl.java
@@ -1,0 +1,73 @@
+package com.yjjjwww.yunmarket.seller.service;
+
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.seller.entity.Seller;
+import com.yjjjwww.yunmarket.seller.model.SellerSignUpServiceForm;
+import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class SellerServiceImpl implements SellerService {
+
+  private final SellerRepository sellerRepository;
+
+  private static final String PHONE_REGEX = "^[0-9]*$";
+  private static final String PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,}$";
+
+  @Override
+  public void signUp(SellerSignUpServiceForm sellerSignUpServiceForm) {
+    Optional<Seller> optionalSeller =
+        sellerRepository.findByEmail(sellerSignUpServiceForm.getEmail());
+
+    optionalSeller.ifPresent(it -> {
+      throw new CustomException(ErrorCode.ALREADY_SIGNUP_EMAIL);
+    });
+
+    if (!isValidPassword(sellerSignUpServiceForm.getPassword())) {
+      throw new CustomException(ErrorCode.INVALID_PASSWORD);
+    }
+
+    if (!isValidPhone(sellerSignUpServiceForm.getPhone())) {
+      throw new CustomException(ErrorCode.INVALID_PHONE);
+    }
+
+    String encPassword = BCrypt.hashpw(sellerSignUpServiceForm.getPassword(), BCrypt.gensalt());
+
+    Seller seller = Seller.builder()
+        .email(sellerSignUpServiceForm.getEmail())
+        .password(encPassword)
+        .phone(sellerSignUpServiceForm.getPhone())
+        .deletedYn(false)
+        .build();
+
+    sellerRepository.save(seller);
+  }
+
+  /**
+   * 핸드폰 번호 형식 검사
+   */
+  private static boolean isValidPhone(String phone) {
+    if (phone.length() > 11 || phone.length() < 5) {
+      return false;
+    }
+    Pattern p = Pattern.compile(PHONE_REGEX);
+    Matcher m = p.matcher(phone);
+    return m.matches();
+  }
+
+  /**
+   * 비밀번호 형식 검사(최소 8자리에 숫자, 문자, 특수문자 각각 1개 이상 포함)
+   */
+  private static boolean isValidPassword(String password) {
+    Pattern p = Pattern.compile(PASSWORD_REGEX);
+    Matcher m = p.matcher(password);
+    return m.matches();
+  }
+}

--- a/src/test/java/com/yjjjwww/yunmarket/seller/controller/SellerControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/seller/controller/SellerControllerTest.java
@@ -1,0 +1,132 @@
+package com.yjjjwww.yunmarket.seller.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.seller.model.SellerSignUpForm;
+import com.yjjjwww.yunmarket.seller.service.SellerService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SellerControllerTest {
+
+  @MockBean
+  private SellerService sellerService;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  void sellerSignUpSuccess() throws Exception {
+    //given
+    SellerSignUpForm form = SellerSignUpForm.builder()
+        .email("yjjjwww@naver.com")
+        .password("zero1234@")
+        .phone("01022223333")
+        .build();
+
+    //when
+    //then
+    mockMvc.perform(post("/seller/signUp")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  void sellerSignUpFail_ALREADY_SIGNUP_EMAIL() throws Exception {
+    //given
+    SellerSignUpForm form = SellerSignUpForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234@")
+        .phone("01011112222")
+        .build();
+
+    doThrow(new CustomException(ErrorCode.ALREADY_SIGNUP_EMAIL))
+        .when(sellerService)
+        .signUp(form.toServiceForm());
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/seller/signUp")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("ALREADY_SIGNUP_EMAIL", code);
+  }
+
+  @Test
+  void sellerSignUpFail_INVALID_PASSWORD() throws Exception {
+    //given
+    SellerSignUpForm form = SellerSignUpForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234")
+        .phone("01011112222")
+        .build();
+
+    doThrow(new CustomException(ErrorCode.INVALID_PASSWORD))
+        .when(sellerService)
+        .signUp(form.toServiceForm());
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/seller/signUp")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("INVALID_PASSWORD", code);
+  }
+
+  @Test
+  void sellerSignUpFail_INVALID_PHONE() throws Exception {
+    //given
+    SellerSignUpForm form = SellerSignUpForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234")
+        .phone("01011112222124352353462436")
+        .build();
+
+    doThrow(new CustomException(ErrorCode.INVALID_PHONE))
+        .when(sellerService)
+        .signUp(form.toServiceForm());
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/seller/signUp")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("INVALID_PHONE", code);
+  }
+}

--- a/src/test/java/com/yjjjwww/yunmarket/seller/service/SellerServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/seller/service/SellerServiceImplTest.java
@@ -1,0 +1,101 @@
+package com.yjjjwww.yunmarket.seller.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.seller.entity.Seller;
+import com.yjjjwww.yunmarket.seller.model.SellerSignUpServiceForm;
+import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SellerServiceImplTest {
+
+  @Mock
+  private SellerRepository sellerRepository;
+
+  @InjectMocks
+  private SellerServiceImpl sellerService;
+
+  @Test
+  void sellerSignUpSuccess() {
+    //given
+    SellerSignUpServiceForm form = SellerSignUpServiceForm.builder()
+        .email("yjjwww@naver.com")
+        .password("zero1234@")
+        .phone("01022223333")
+        .build();
+
+    //when
+    sellerService.signUp(form);
+
+    //then
+    verify(sellerRepository, times(1)).save(any(Seller.class));
+  }
+
+  @Test
+  void sellerSignUpFail_ALREADY_SIGNUP_EMAIL() {
+    //given
+    SellerSignUpServiceForm form = SellerSignUpServiceForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234@")
+        .phone("01011112222")
+        .build();
+
+    given(sellerRepository.findByEmail(anyString()))
+        .willReturn(Optional.ofNullable(Seller.builder().build()));
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> sellerService.signUp(form));
+
+    //then
+    assertEquals(ErrorCode.ALREADY_SIGNUP_EMAIL, exception.getErrorCode());
+  }
+
+  @Test
+  void sellerSignUpFail_INVALID_PASSWORD() {
+    //given
+    SellerSignUpServiceForm form = SellerSignUpServiceForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234")
+        .phone("01011112222")
+        .build();
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> sellerService.signUp(form));
+
+    //then
+    assertEquals(ErrorCode.INVALID_PASSWORD, exception.getErrorCode());
+  }
+
+  @Test
+  void sellerSignUpFail_INVALID_PHONE() {
+    //given
+    SellerSignUpServiceForm form = SellerSignUpServiceForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234@")
+        .phone("010111122221231242151353253241342141")
+        .build();
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> sellerService.signUp(form));
+
+    //then
+    assertEquals(ErrorCode.INVALID_PHONE, exception.getErrorCode());
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- Seller 엔티티 설정했습니다. Seller 데이터베이스에는 이메일, 비밀번호, 연락처를 저장합니다.
- 회원가입시 이미 등록된 이메일이 있는지 확인합니다.
- 회원가입시 비밀번호 유효성 검사, 연락처 형식 유효성 검사를 합니다.
- Seller 비밀번호는 암호화해서 데이터베이스에 저장합니다.
- postman으로 API 테스트 완료했고, 테스트 코드로 성공할 경우와 Custom Error가 발생할 경우 올바른 응답이 나오는지 확인했습니다.

**TO-BE**
- Customer, Seller 로그인

### 테스트
- [x] 테스트 코드
- [x] API 테스트 