### PR TITLE
feat : Customer 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/yjjjwww/yunmarket/common/UserType.java
+++ b/src/main/java/com/yjjjwww/yunmarket/common/UserType.java
@@ -1,0 +1,6 @@
+package com.yjjjwww.yunmarket.common;
+
+public enum UserType {
+  CUSTOMER,
+  SELLER
+}

--- a/src/main/java/com/yjjjwww/yunmarket/common/UserVo.java
+++ b/src/main/java/com/yjjjwww/yunmarket/common/UserVo.java
@@ -1,0 +1,12 @@
+package com.yjjjwww.yunmarket.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UserVo {
+
+  private Long id;
+  private String email;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/config/JwtTokenFilter.java
+++ b/src/main/java/com/yjjjwww/yunmarket/config/JwtTokenFilter.java
@@ -1,0 +1,44 @@
+package com.yjjjwww.yunmarket.config;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+  public static final String TOKEN_HEADER = "Authorization";
+  public static final String TOKEN_PREFIX = "Bearer ";
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    try {
+      String jwtToken = getTokenFromRequest(request);
+      if (StringUtils.hasText(jwtToken) && jwtTokenProvider.validateToken(jwtToken)) {
+        Authentication authentication = jwtTokenProvider.getAuthentication(jwtToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      }
+    } catch (Exception e) {
+      logger.error("Failed to set user authentication in security context", e);
+    }
+    filterChain.doFilter(request, response);
+  }
+
+  private String getTokenFromRequest(HttpServletRequest request) {
+    String bearerToken = request.getHeader(TOKEN_HEADER);
+    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(TOKEN_PREFIX)) {
+      return bearerToken.substring(TOKEN_PREFIX.length());
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/config/JwtTokenProvider.java
+++ b/src/main/java/com/yjjjwww/yunmarket/config/JwtTokenProvider.java
@@ -1,0 +1,73 @@
+package com.yjjjwww.yunmarket.config;
+
+import com.yjjjwww.yunmarket.common.UserType;
+import com.yjjjwww.yunmarket.common.UserVo;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+  @Value("${jwt.secret.key}")
+  private String secretKey;
+
+  private static final long TOKEN_EXPIRE = 1000 * 60 * 60;
+
+  private static final String USERTYPE = "userType";
+  public static final String TOKEN_PREFIX = "Bearer ";
+
+  public String createToken(String email, Long id, UserType userType) {
+    Claims claims = Jwts.claims().setSubject(email).setId(id.toString());
+    claims.put(USERTYPE, userType.toString());
+    Date now = new Date();
+    return Jwts.builder()
+        .setClaims(claims)
+        .setIssuedAt(now)
+        .setExpiration(new Date(now.getTime() + TOKEN_EXPIRE))
+        .signWith(SignatureAlgorithm.HS256, secretKey)
+        .compact();
+  }
+
+  public Authentication getAuthentication(String token) {
+    Claims claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+
+    String username = claims.getSubject();
+    String userType = claims.get("userType", String.class);
+    List<SimpleGrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(new SimpleGrantedAuthority("ROLE_" + userType));
+
+    UserDetails userDetails = new User(username, "", authorities);
+
+    return new UsernamePasswordAuthenticationToken(userDetails, "",
+        userDetails.getAuthorities());
+  }
+
+  public boolean validateToken(String token) {
+    try {
+      Jws<Claims> claimsJws = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+      return !claimsJws.getBody().getExpiration().before(new Date());
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  public UserVo getUserVo(String token) {
+    Claims claims = Jwts.parser().setSigningKey(secretKey)
+        .parseClaimsJws(token.substring(TOKEN_PREFIX.length())).getBody();
+    return new UserVo(Long.parseLong(Objects.requireNonNull(claims.getId())),
+        claims.getSubject());
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/customer/controller/CustomerController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/controller/CustomerController.java
@@ -1,5 +1,6 @@
 package com.yjjjwww.yunmarket.customer.controller;
 
+import com.yjjjwww.yunmarket.customer.model.CustomerSignInForm;
 import com.yjjjwww.yunmarket.customer.model.CustomerSignUpForm;
 import com.yjjjwww.yunmarket.customer.service.CustomerService;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +22,10 @@ public class CustomerController {
   public ResponseEntity<String> signUp(@RequestBody CustomerSignUpForm customerSignUpForm) {
     customerService.signUp(customerSignUpForm.toServiceForm());
     return ResponseEntity.ok(SIGNUP_SUCCESS);
+  }
+
+  @PostMapping("/signIn")
+  public ResponseEntity<String> signIn(@RequestBody CustomerSignInForm customerSignInForm) {
+    return ResponseEntity.ok(customerService.signIn(customerSignInForm.toServiceForm()));
   }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/customer/model/CustomerSignInForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/model/CustomerSignInForm.java
@@ -1,0 +1,23 @@
+package com.yjjjwww.yunmarket.customer.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomerSignInForm {
+
+  private String email;
+  private String password;
+
+  public CustomerSignInServiceForm toServiceForm() {
+    return CustomerSignInServiceForm.builder()
+        .email(email)
+        .password(password)
+        .build();
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/customer/model/CustomerSignInServiceForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/model/CustomerSignInServiceForm.java
@@ -1,0 +1,16 @@
+package com.yjjjwww.yunmarket.customer.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomerSignInServiceForm {
+
+  private String email;
+  private String password;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/customer/service/CustomerService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/service/CustomerService.java
@@ -1,5 +1,6 @@
 package com.yjjjwww.yunmarket.customer.service;
 
+import com.yjjjwww.yunmarket.customer.model.CustomerSignInServiceForm;
 import com.yjjjwww.yunmarket.customer.model.CustomerSignUpServiceForm;
 
 public interface CustomerService {
@@ -8,4 +9,9 @@ public interface CustomerService {
    * Customer 회원가입
    */
   void signUp(CustomerSignUpServiceForm customerSignUpServiceForm);
+
+  /**
+   * Customer 로그인
+   */
+  String signIn(CustomerSignInServiceForm customerSignInServiceForm);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
+++ b/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 @Getter
 public enum ErrorCode {
+  LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "아이디나 패스워드를 확인해 주세요."),
   INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자리에 숫자, 문자, 특수문자 각각 1개 이상 포함해야 합니다."),
   INVALID_PHONE(HttpStatus.BAD_REQUEST, "핸드폰 번호 형식을 확인해주세요."),
   ALREADY_SIGNUP_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다.");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,5 @@ spring.datasource.password=yjw202020@
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
+
+jwt.secret.key=yunmarket1234

--- a/src/test/java/com/yjjjwww/yunmarket/customer/controller/CustomerControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/customer/controller/CustomerControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yjjjwww.yunmarket.customer.model.CustomerSignInForm;
 import com.yjjjwww.yunmarket.customer.model.CustomerSignUpForm;
 import com.yjjjwww.yunmarket.customer.service.CustomerService;
 import com.yjjjwww.yunmarket.exception.CustomException;
@@ -132,5 +133,47 @@ class CustomerControllerTest {
     String code = responseJson.get("code").asText();
 
     assertEquals("INVALID_PHONE", code);
+  }
+
+  @Test
+  void customerSignInSuccess() throws Exception {
+    //given
+    CustomerSignInForm form = CustomerSignInForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234@")
+        .build();
+
+    //when
+    //then
+    mockMvc.perform(post("/customer/signIn")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  void customerSignInFail_LOGIN_CHECK_FAIL() throws Exception {
+    //given
+    CustomerSignInForm form = CustomerSignInForm.builder()
+        .email("yjjjwww123@naver.com")
+        .password("zero1234@")
+        .build();
+
+    doThrow(new CustomException(ErrorCode.LOGIN_CHECK_FAIL))
+        .when(customerService)
+        .signIn(form.toServiceForm());
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/customer/signIn")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("LOGIN_CHECK_FAIL", code);
   }
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- Customer 로그인 기능 구현했습니다. 요청으로 이메일, 비밀번호 값을 받습니다.
- 해당 이메일을 가진 Customer를 데이터베이스 조회하고, 암호화된 비밀번호를 비교합니다.
- 해당 이메일을 가진 Customer가 존재하지 않거나 비밀번호가 일치하지 않을 경우, LOGIN_CHECK_FAIL 에러가 납니다.
- 로그인에 성공하면 Customer id, email, Customer role 정보를 가진 JWT 토큰이 발급됩니다.
- postman으로 API 테스트 완료했고, 테스트 코드로 성공할 경우와 Custom Error가 발생할 경우 올바른 응답이 나오는지 확인했습니다.

**TO-BE**
- Seller 로그인

### 테스트
- [x] 테스트 코드
- [x] API 테스트 