### PR TITLE
feat : Seller 로그인 기능 구현

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/seller/controller/SellerController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/seller/controller/SellerController.java
@@ -1,5 +1,6 @@
 package com.yjjjwww.yunmarket.seller.controller;
 
+import com.yjjjwww.yunmarket.seller.model.SellerSignInForm;
 import com.yjjjwww.yunmarket.seller.model.SellerSignUpForm;
 import com.yjjjwww.yunmarket.seller.service.SellerService;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +22,10 @@ public class SellerController {
   public ResponseEntity<String> signUp(@RequestBody SellerSignUpForm sellerSignUpForm) {
     sellerService.signUp(sellerSignUpForm.toServiceForm());
     return ResponseEntity.ok(SIGNUP_SUCCESS);
+  }
+
+  @PostMapping("signIn")
+  public ResponseEntity<String> signIn(@RequestBody SellerSignInForm sellerSignInForm) {
+    return ResponseEntity.ok(sellerService.signIn(sellerSignInForm.toServiceForm()));
   }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/seller/model/SellerSignInForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/seller/model/SellerSignInForm.java
@@ -1,0 +1,23 @@
+package com.yjjjwww.yunmarket.seller.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SellerSignInForm {
+
+  private String email;
+  private String password;
+
+  public SellerSignInServiceForm toServiceForm() {
+    return SellerSignInServiceForm.builder()
+        .email(email)
+        .password(password)
+        .build();
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/seller/model/SellerSignInServiceForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/seller/model/SellerSignInServiceForm.java
@@ -1,0 +1,16 @@
+package com.yjjjwww.yunmarket.seller.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SellerSignInServiceForm {
+
+  private String email;
+  private String password;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/seller/service/SellerService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/seller/service/SellerService.java
@@ -1,5 +1,6 @@
 package com.yjjjwww.yunmarket.seller.service;
 
+import com.yjjjwww.yunmarket.seller.model.SellerSignInServiceForm;
 import com.yjjjwww.yunmarket.seller.model.SellerSignUpServiceForm;
 
 public interface SellerService {
@@ -8,4 +9,9 @@ public interface SellerService {
    * Seller 회원가입
    */
   void signUp(SellerSignUpServiceForm sellerSignUpServiceForm);
+
+  /**
+   * Seller 로그인
+   */
+  String signIn(SellerSignInServiceForm sellerSignInServiceForm);
 }

--- a/src/test/java/com/yjjjwww/yunmarket/seller/controller/SellerControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/seller/controller/SellerControllerTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yjjjwww.yunmarket.exception.CustomException;
 import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.seller.model.SellerSignInForm;
 import com.yjjjwww.yunmarket.seller.model.SellerSignUpForm;
 import com.yjjjwww.yunmarket.seller.service.SellerService;
 import org.junit.jupiter.api.Test;
@@ -128,5 +129,47 @@ class SellerControllerTest {
     String code = responseJson.get("code").asText();
 
     assertEquals("INVALID_PHONE", code);
+  }
+
+  @Test
+  void sellerSignInSuccess() throws Exception {
+    //given
+    SellerSignInForm form = SellerSignInForm.builder()
+        .email("yjjjwww@naver.com")
+        .password("zero1234@")
+        .build();
+
+    //when
+    //then
+    mockMvc.perform(post("/seller/signIn")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  void sellerSignInFail_LOGIN_CHECK_FAIL() throws Exception {
+    //given
+    SellerSignInForm form = SellerSignInForm.builder()
+        .email("yjjjwww@naver.com")
+        .password("zero1234@")
+        .build();
+
+    doThrow(new CustomException(ErrorCode.LOGIN_CHECK_FAIL))
+        .when(sellerService)
+        .signIn(form.toServiceForm());
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/seller/signIn")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("LOGIN_CHECK_FAIL", code);
   }
 }

--- a/src/test/java/com/yjjjwww/yunmarket/seller/service/SellerServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/seller/service/SellerServiceImplTest.java
@@ -1,16 +1,20 @@
 package com.yjjjwww.yunmarket.seller.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.yjjjwww.yunmarket.config.JwtTokenProvider;
 import com.yjjjwww.yunmarket.exception.CustomException;
 import com.yjjjwww.yunmarket.exception.ErrorCode;
 import com.yjjjwww.yunmarket.seller.entity.Seller;
+import com.yjjjwww.yunmarket.seller.model.SellerSignInServiceForm;
 import com.yjjjwww.yunmarket.seller.model.SellerSignUpServiceForm;
 import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
 import java.util.Optional;
@@ -19,12 +23,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCrypt;
 
 @ExtendWith(MockitoExtension.class)
 class SellerServiceImplTest {
 
   @Mock
   private SellerRepository sellerRepository;
+
+  @Mock
+  private JwtTokenProvider provider;
 
   @InjectMocks
   private SellerServiceImpl sellerService;
@@ -97,5 +105,73 @@ class SellerServiceImplTest {
 
     //then
     assertEquals(ErrorCode.INVALID_PHONE, exception.getErrorCode());
+  }
+
+  @Test
+  void sellerSignInSuccess() {
+    //given
+    SellerSignInServiceForm form = SellerSignInServiceForm.builder()
+        .email("yjjjwww@naver.com")
+        .password("zero1111")
+        .build();
+
+    Seller seller = Seller.builder()
+        .id(1L)
+        .email("yjjjwww@naver.com")
+        .password(BCrypt.hashpw("zero1111", BCrypt.gensalt()))
+        .build();
+
+    given(sellerRepository.findByEmail(anyString())).willReturn(Optional.ofNullable(seller));
+    given(provider.createToken(anyString(), anyLong(), any())).willReturn("JWT Token");
+
+    //when
+    String token = sellerService.signIn(form);
+
+    //then
+    assertNotNull(token);
+  }
+
+  @Test
+  void sellerSignInFail_LOGIN_CHECK_FAIL_No_Email() {
+    //given
+    SellerSignInServiceForm form = SellerSignInServiceForm.builder()
+        .email("yjjjwww@naver.com")
+        .password("zero1111")
+        .build();
+
+    given(sellerRepository.findByEmail(anyString())).willReturn(
+        Optional.ofNullable(Seller.builder().build()));
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> sellerService.signIn(form));
+
+    //then
+    assertEquals(ErrorCode.LOGIN_CHECK_FAIL, exception.getErrorCode());
+  }
+
+  @Test
+  void sellerSignInFail_LOGIN_CHECK_FAIL_Invalid_Password() {
+    //given
+    SellerSignInServiceForm form = SellerSignInServiceForm.builder()
+        .email("yjjjwww@naver.com")
+        .password("zero1111")
+        .build();
+
+    Seller seller = Seller.builder()
+        .id(1L)
+        .email("yjjjwww@naver.com")
+        .password("Wrong Password")
+        .build();
+
+    given(sellerRepository.findByEmail(anyString())).willReturn(
+        Optional.ofNullable(seller));
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> sellerService.signIn(form));
+
+    //then
+    assertEquals(ErrorCode.LOGIN_CHECK_FAIL, exception.getErrorCode());
   }
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- Seller 로그인 기능 구현했습니다. 요청으로 이메일, 비밀번호 값을 받습니다.
- 해당 이메일을 가진 Seller를 데이터베이스 조회하고, 암호화된 비밀번호를 비교합니다.
- 해당 이메일을 가진 Seller가 존재하지 않거나 비밀번호가 일치하지 않을 경우, LOGIN_CHECK_FAIL 에러가 납니다.
- 로그인에 성공하면 Seller id, email, Seller role 정보를 가진 JWT 토큰이 발급됩니다.
- postman으로 API 테스트 완료했고, 테스트 코드로 성공할 경우와 Custom Error가 발생할 경우 올바른 응답이 나오는지 확인했습니다.

**TO-BE**
- Seller 상품 등록하기

### 테스트
- [x] 테스트 코드
- [x] API 테스트 