### PR TITLE
feat : Seller 상품 등록 기능 구현

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/config/SecurityConfig.java
+++ b/src/main/java/com/yjjjwww/yunmarket/config/SecurityConfig.java
@@ -10,12 +10,15 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final JwtTokenProvider provider;
 
   @Bean
   public PasswordEncoder getPasswordEncoder() {
@@ -29,7 +32,10 @@ public class SecurityConfig {
         .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         .and()
         .authorizeRequests()
-        .antMatchers("/**/signUp", "/**/signIn").permitAll();
+        .antMatchers("/**/signUp", "/**/signIn").permitAll()
+        .and()
+        .addFilterBefore(new JwtTokenFilter(provider),
+            UsernamePasswordAuthenticationFilter.class);
 
     return http.build();
   }

--- a/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
+++ b/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
@@ -7,6 +7,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 @Getter
 public enum ErrorCode {
+  INVALID_PRODUCT_REGISTER(HttpStatus.BAD_REQUEST, "상품 등록 내용을 확인해주세요."),
+  USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."),
+  CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "카테고리를 찾을 수 없습니다."),
   LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "아이디나 패스워드를 확인해 주세요."),
   INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자리에 숫자, 문자, 특수문자 각각 1개 이상 포함해야 합니다."),
   INVALID_PHONE(HttpStatus.BAD_REQUEST, "핸드폰 번호 형식을 확인해주세요."),

--- a/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
@@ -1,0 +1,32 @@
+package com.yjjjwww.yunmarket.product.controller;
+
+import com.yjjjwww.yunmarket.product.model.ProductRegisterForm;
+import com.yjjjwww.yunmarket.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/product")
+public class ProductController {
+
+  private final ProductService productService;
+  public static final String TOKEN_HEADER = "Authorization";
+
+  private static final String REGISTER_PRODUCT_SUCCESS = "상품 등록 완료";
+
+  @PostMapping
+  @PreAuthorize("hasRole('SELLER')")
+  public ResponseEntity<String> registerProduct(
+      @RequestHeader(name = TOKEN_HEADER) String token,
+      @RequestBody ProductRegisterForm productRegisterForm) {
+    productService.register(token, productRegisterForm.toServiceForm());
+    return ResponseEntity.ok(REGISTER_PRODUCT_SUCCESS);
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/product/entity/Category.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/entity/Category.java
@@ -1,7 +1,5 @@
-package com.yjjjwww.yunmarket.seller.entity;
+package com.yjjjwww.yunmarket.product.entity;
 
-import com.yjjjwww.yunmarket.entity.BaseEntity;
-import com.yjjjwww.yunmarket.product.entity.Product;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
@@ -14,30 +12,24 @@ import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-@EqualsAndHashCode(callSuper = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Data
 @Entity
-public class Seller extends BaseEntity {
+public class Category {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @Column(unique = true)
-  String email;
+  String name;
 
-  String password;
-  String phone;
-  boolean deletedYn;
-
-  @OneToMany(mappedBy = "seller", fetch = FetchType.EAGER)
+  @OneToMany(mappedBy = "category", fetch = FetchType.EAGER)
   @ToString.Exclude
   private List<Product> productList = new ArrayList<>();
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/entity/Product.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/entity/Product.java
@@ -1,16 +1,13 @@
-package com.yjjjwww.yunmarket.seller.entity;
+package com.yjjjwww.yunmarket.product.entity;
 
 import com.yjjjwww.yunmarket.entity.BaseEntity;
-import com.yjjjwww.yunmarket.product.entity.Product;
-import java.util.ArrayList;
-import java.util.List;
-import javax.persistence.Column;
+import com.yjjjwww.yunmarket.seller.entity.Seller;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -24,20 +21,27 @@ import lombok.ToString;
 @Builder
 @Data
 @Entity
-public class Seller extends BaseEntity {
+public class Product extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(unique = true)
-  String email;
-
-  String password;
-  String phone;
-  boolean deletedYn;
-
-  @OneToMany(mappedBy = "seller", fetch = FetchType.EAGER)
+  @ManyToOne
+  @JoinColumn(name = "category_id")
   @ToString.Exclude
-  private List<Product> productList = new ArrayList<>();
+  private Category category;
+
+  @ManyToOne
+  @JoinColumn(name = "seller_id")
+  @ToString.Exclude
+  private Seller seller;
+
+  String name;
+  Integer price;
+  String description;
+  Integer quantity;
+  String image;
+  Integer orderedCnt;
+  boolean deletedYn;
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/model/ProductRegisterForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/model/ProductRegisterForm.java
@@ -1,0 +1,31 @@
+package com.yjjjwww.yunmarket.product.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductRegisterForm {
+
+  String name;
+  Long categoryId;
+  Integer price;
+  String description;
+  Integer quantity;
+  String image;
+
+  public ProductRegisterServiceForm toServiceForm() {
+    return ProductRegisterServiceForm.builder()
+        .name(name)
+        .categoryId(categoryId)
+        .price(price)
+        .description(description)
+        .quantity(quantity)
+        .image(image)
+        .build();
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/product/model/ProductRegisterServiceForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/model/ProductRegisterServiceForm.java
@@ -1,0 +1,20 @@
+package com.yjjjwww.yunmarket.product.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductRegisterServiceForm {
+
+  String name;
+  Long categoryId;
+  Integer price;
+  String description;
+  Integer quantity;
+  String image;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/product/repository/CategoryRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.yjjjwww.yunmarket.product.repository;
+
+import com.yjjjwww.yunmarket.product.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+}

--- a/src/main/java/com/yjjjwww/yunmarket/product/repository/ProductRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/repository/ProductRepository.java
@@ -1,0 +1,8 @@
+package com.yjjjwww.yunmarket.product.repository;
+
+import com.yjjjwww.yunmarket.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+}

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
@@ -1,0 +1,11 @@
+package com.yjjjwww.yunmarket.product.service;
+
+import com.yjjjwww.yunmarket.product.model.ProductRegisterServiceForm;
+
+public interface ProductService {
+
+  /**
+   * 상품 등록
+   */
+  void register(String token, ProductRegisterServiceForm productRegisterServiceForm);
+}

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
@@ -1,0 +1,59 @@
+package com.yjjjwww.yunmarket.product.service;
+
+import com.yjjjwww.yunmarket.common.UserVo;
+import com.yjjjwww.yunmarket.config.JwtTokenProvider;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.product.entity.Category;
+import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.product.model.ProductRegisterServiceForm;
+import com.yjjjwww.yunmarket.product.repository.CategoryRepository;
+import com.yjjjwww.yunmarket.product.repository.ProductRepository;
+import com.yjjjwww.yunmarket.seller.entity.Seller;
+import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ProductServiceImpl implements ProductService {
+
+  private final JwtTokenProvider provider;
+  private final SellerRepository sellerRepository;
+  private final ProductRepository productRepository;
+  private final CategoryRepository categoryRepository;
+
+  @Override
+  public void register(String token, ProductRegisterServiceForm form) {
+    if (isStringEmpty(form.getName()) || form.getPrice() <= 0 || isStringEmpty(
+        form.getDescription()) || form.getQuantity() <= 0) {
+      throw new CustomException(ErrorCode.INVALID_PRODUCT_REGISTER);
+    }
+
+    UserVo vo = provider.getUserVo(token);
+
+    Seller seller = sellerRepository.findByEmail(vo.getEmail())
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+    Category category = categoryRepository.findById(form.getCategoryId())
+        .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
+
+    Product product = Product.builder()
+        .category(category)
+        .seller(seller)
+        .name(form.getName())
+        .price(form.getPrice())
+        .description(form.getDescription())
+        .quantity(form.getQuantity())
+        .image(form.getImage())
+        .orderedCnt(0)
+        .deletedYn(false)
+        .build();
+
+    productRepository.save(product);
+  }
+
+  private static boolean isStringEmpty(String str) {
+    return str == null || str.isBlank();
+  }
+}

--- a/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
@@ -1,0 +1,191 @@
+package com.yjjjwww.yunmarket.product.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yjjjwww.yunmarket.common.UserType;
+import com.yjjjwww.yunmarket.config.JwtTokenProvider;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.product.model.ProductRegisterForm;
+import com.yjjjwww.yunmarket.product.service.ProductService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ProductControllerTest {
+
+  @MockBean
+  private ProductService productService;
+
+  @MockBean
+  private JwtTokenProvider provider;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  @WithMockUser(roles = "SELLER")
+  void sellerProductRegisterSuccess() throws Exception {
+    ProductRegisterForm form = ProductRegisterForm.builder()
+        .name("판매상품")
+        .categoryId(4L)
+        .price(10000)
+        .description("판매상품입니다.")
+        .quantity(1000)
+        .image("이미지주소")
+        .build();
+
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.SELLER);
+
+    //when
+    //then
+    mockMvc.perform(post("/product")
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @WithMockUser(roles = "CUSTOMER")
+  void sellerProductRegisterFail_CUSTOMER_CANNOT_REGISTER() throws Exception {
+    ProductRegisterForm form = ProductRegisterForm.builder()
+        .name("판매상품")
+        .categoryId(4L)
+        .price(10000)
+        .description("판매상품입니다.")
+        .quantity(1000)
+        .image("이미지주소")
+        .build();
+
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.CUSTOMER);
+
+    //when
+    //then
+    mockMvc.perform(post("/product")
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isForbidden())
+        .andDo(print());
+  }
+
+  @Test
+  @WithMockUser(roles = "SELLER")
+  void sellerProductRegisterFail_INVALID_PRODUCT_REGISTER() throws Exception {
+    ProductRegisterForm form = ProductRegisterForm.builder()
+        .name("")
+        .categoryId(4L)
+        .price(0)
+        .description("")
+        .quantity(0)
+        .image("이미지주소")
+        .build();
+
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.SELLER);
+
+    doThrow(new CustomException(ErrorCode.INVALID_PRODUCT_REGISTER))
+        .when(productService)
+        .register(anyString(), any());
+
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/product")
+        .header("Authorization", "Bearer " + token)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("INVALID_PRODUCT_REGISTER", code);
+  }
+
+  @Test
+  @WithMockUser(roles = "SELLER")
+  void sellerProductRegisterFail_USER_NOT_FOUND() throws Exception {
+    ProductRegisterForm form = ProductRegisterForm.builder()
+        .name("")
+        .categoryId(4L)
+        .price(0)
+        .description("")
+        .quantity(0)
+        .image("이미지주소")
+        .build();
+
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.SELLER);
+
+    doThrow(new CustomException(ErrorCode.USER_NOT_FOUND))
+        .when(productService)
+        .register(anyString(), any());
+
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/product")
+        .header("Authorization", "Bearer " + token)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("USER_NOT_FOUND", code);
+  }
+
+  @Test
+  @WithMockUser(roles = "SELLER")
+  void sellerProductRegisterFail_CATEGORY_NOT_FOUND() throws Exception {
+    ProductRegisterForm form = ProductRegisterForm.builder()
+        .name("")
+        .categoryId(4L)
+        .price(0)
+        .description("")
+        .quantity(0)
+        .image("이미지주소")
+        .build();
+
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.SELLER);
+
+    doThrow(new CustomException(ErrorCode.CATEGORY_NOT_FOUND))
+        .when(productService)
+        .register(anyString(), any());
+
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/product")
+        .header("Authorization", "Bearer " + token)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("CATEGORY_NOT_FOUND", code);
+  }
+}

--- a/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
@@ -1,0 +1,144 @@
+package com.yjjjwww.yunmarket.product.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.yjjjwww.yunmarket.common.UserVo;
+import com.yjjjwww.yunmarket.config.JwtTokenProvider;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.product.entity.Category;
+import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.product.model.ProductRegisterServiceForm;
+import com.yjjjwww.yunmarket.product.repository.CategoryRepository;
+import com.yjjjwww.yunmarket.product.repository.ProductRepository;
+import com.yjjjwww.yunmarket.seller.entity.Seller;
+import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceImplTest {
+
+  @Mock
+  private SellerRepository sellerRepository;
+
+  @Mock
+  private ProductRepository productRepository;
+
+  @Mock
+  private CategoryRepository categoryRepository;
+
+  @Mock
+  private JwtTokenProvider provider;
+
+  @InjectMocks
+  private ProductServiceImpl productService;
+
+  @Test
+  void sellerProductRegisterSuccess() {
+    //given
+    ProductRegisterServiceForm form = ProductRegisterServiceForm.builder()
+        .name("판매상품")
+        .categoryId(1L)
+        .price(1000)
+        .description("상품 설명")
+        .quantity(400)
+        .image("이미지 주소")
+        .build();
+
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    given(sellerRepository.findByEmail(anyString())).willReturn(
+        Optional.ofNullable(Seller.builder().build()));
+
+    given(categoryRepository.findById(anyLong())).willReturn(
+        Optional.ofNullable(Category.builder().build()));
+
+    //when
+    productService.register("jwt", form);
+
+    //then
+    verify(productRepository, times(1)).save(any(Product.class));
+  }
+
+  @Test
+  void sellerProductRegisterFail_INVALID_PRODUCT_REGISTER() {
+    //given
+    ProductRegisterServiceForm form = ProductRegisterServiceForm.builder()
+        .name("")
+        .categoryId(1L)
+        .price(1000)
+        .description("상품 설명")
+        .quantity(400)
+        .image("이미지 주소")
+        .build();
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> productService.register("token", form));
+
+    //then
+    assertEquals(ErrorCode.INVALID_PRODUCT_REGISTER, exception.getErrorCode());
+  }
+
+  @Test
+  void sellerProductRegisterFail_USER_NOT_FOUND() {
+    //given
+    ProductRegisterServiceForm form = ProductRegisterServiceForm.builder()
+        .name("판매 상품")
+        .categoryId(1L)
+        .price(1000)
+        .description("상품 설명")
+        .quantity(400)
+        .image("이미지 주소")
+        .build();
+
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> productService.register("token", form));
+
+    //then
+    assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+  }
+
+  @Test
+  void sellerProductRegisterFail_CATEGORY_NOT_FOUND() {
+    //given
+    ProductRegisterServiceForm form = ProductRegisterServiceForm.builder()
+        .name("판매 상품")
+        .categoryId(1L)
+        .price(1000)
+        .description("상품 설명")
+        .quantity(400)
+        .image("이미지 주소")
+        .build();
+
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    given(sellerRepository.findByEmail(anyString())).willReturn(
+        Optional.ofNullable(Seller.builder().build()));
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> productService.register("token", form));
+
+    //then
+    assertEquals(ErrorCode.CATEGORY_NOT_FOUND, exception.getErrorCode());
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- Seller인 사용자가 상품 등록하는 기능 구현했습니다. Customer로 로그인해서 발급받은 JWT 토큰을 가지고 상품 등록을 하면 403 응답이 발생합니다.
- Product 엔티티를 설정했습니다. Product 데이터베이스에는 이름, 가격, 상품 설명, 수량, 이미지 주소, 주문 횟수, 삭제 여부가 저장되고, 카테고리와 판매자 데이터베이스와 ManyToOne 연관관계가 있습니다. Seller 엔티티에 Product와 OneToMany 연관관계를 추가하여 판매자가 등록한 상품 목록들을 조회할 수 있도록 했습니다.
- 상품 등록시 상품 이름이 비어있거나, 상품 가격이 0 이하이거나, 상품 설명이 비어있거나, 상품 수량이 0 이하이면 Custom Error가 발생합니다. JWT토큰에 담긴 정보로 Seller를 조회했을 때 Seller가 존재하지 않으면 Custom Error가 발생합니다. 카테고리가 존재하지 않을 경우 Custom Error가 발생합니다.
- 기본 주문 횟수는 0으로 저장됩니다.
- postman으로 API 테스트 완료했고, 테스트 코드로 성공할 경우와 Custom Error가 발생할 경우 올바른 응답이 나오는지 확인했습니다. 사용자 role에 따라 정상적으로 응답하는지 테스트 했습니다.

**TO-BE**
- 상품 조회하기

### 테스트
- [x] 테스트 코드
- [x] API 테스트 