### PR TITLE
feat : 상품 최신순 조회 기능 구현

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
@@ -1,14 +1,18 @@
 package com.yjjjwww.yunmarket.product.controller;
 
+import com.yjjjwww.yunmarket.product.model.ProductInfo;
 import com.yjjjwww.yunmarket.product.model.ProductRegisterForm;
 import com.yjjjwww.yunmarket.product.service.ProductService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -28,5 +32,13 @@ public class ProductController {
       @RequestBody ProductRegisterForm productRegisterForm) {
     productService.register(token, productRegisterForm.toServiceForm());
     return ResponseEntity.ok(REGISTER_PRODUCT_SUCCESS);
+  }
+
+  @GetMapping("/search/latest")
+  public ResponseEntity<List<ProductInfo>> getLatestProducts(
+      @RequestParam("page") Integer page,
+      @RequestParam("size") Integer size
+  ) {
+    return ResponseEntity.ok(productService.getLatestProducts(page, size));
   }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/model/ProductInfo.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/model/ProductInfo.java
@@ -1,5 +1,8 @@
 package com.yjjjwww.yunmarket.product.model;
 
+import com.yjjjwww.yunmarket.product.entity.Product;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,10 +14,23 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ProductInfo {
 
-  String name;
-  Integer price;
-  String description;
-  Integer quantity;
-  String image;
-  String categoryName;
+  private String name;
+  private Integer price;
+  private String description;
+  private Integer quantity;
+  private String image;
+  private String categoryName;
+
+  public static List<ProductInfo> toList(List<Product> products) {
+    return products.stream()
+        .map(product -> ProductInfo.builder()
+            .name(product.getName())
+            .price(product.getPrice())
+            .description(product.getDescription())
+            .quantity(product.getQuantity())
+            .image(product.getImage())
+            .categoryName(product.getCategory().getName())
+            .build())
+        .collect(Collectors.toList());
+  }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/model/ProductInfo.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/model/ProductInfo.java
@@ -1,0 +1,20 @@
+package com.yjjjwww.yunmarket.product.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductInfo {
+
+  String name;
+  Integer price;
+  String description;
+  Integer quantity;
+  String image;
+  String categoryName;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/product/repository/ProductRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/repository/ProductRepository.java
@@ -3,11 +3,9 @@ package com.yjjjwww.yunmarket.product.repository;
 import com.yjjjwww.yunmarket.product.entity.Product;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends PagingAndSortingRepository<Product, Long> {
 
-  @Query("SELECT p FROM Product p JOIN FETCH p.category ORDER BY p.createdDate DESC")
-  List<Product> findAllByOrderByCreatedDateDesc(Pageable pageable);
+  List<Product> findAllBy(Pageable pageable);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/repository/ProductRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/repository/ProductRepository.java
@@ -1,8 +1,13 @@
 package com.yjjjwww.yunmarket.product.repository;
 
 import com.yjjjwww.yunmarket.product.entity.Product;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
+  @Query("SELECT p FROM Product p JOIN FETCH p.category ORDER BY p.createdDate DESC")
+  List<Product> findAllByOrderByCreatedDateDesc(Pageable pageable);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
@@ -1,6 +1,8 @@
 package com.yjjjwww.yunmarket.product.service;
 
+import com.yjjjwww.yunmarket.product.model.ProductInfo;
 import com.yjjjwww.yunmarket.product.model.ProductRegisterServiceForm;
+import java.util.List;
 
 public interface ProductService {
 
@@ -8,4 +10,9 @@ public interface ProductService {
    * 상품 등록
    */
   void register(String token, ProductRegisterServiceForm productRegisterServiceForm);
+
+  /**
+   * 상품 최신순 조회
+   */
+  List<ProductInfo> getLatestProducts(Integer page, Integer size);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
@@ -12,11 +12,11 @@ import com.yjjjwww.yunmarket.product.repository.CategoryRepository;
 import com.yjjjwww.yunmarket.product.repository.ProductRepository;
 import com.yjjjwww.yunmarket.seller.entity.Seller;
 import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -60,24 +60,11 @@ public class ProductServiceImpl implements ProductService {
 
   @Override
   public List<ProductInfo> getLatestProducts(Integer page, Integer size) {
-    Pageable pageable = PageRequest.of(page - 1, size);
-    List<Product> products = productRepository.findAllByOrderByCreatedDateDesc(pageable);
+    Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdDate").descending());
 
-    List<ProductInfo> result = new ArrayList<>();
+    List<Product> products = productRepository.findAllBy(pageable);
 
-    for (Product product : products) {
-      ProductInfo productInfo = ProductInfo.builder()
-          .name(product.getName())
-          .price(product.getPrice())
-          .description(product.getDescription())
-          .quantity(product.getQuantity())
-          .image(product.getImage())
-          .categoryName(product.getCategory().getName())
-          .build();
-      result.add(productInfo);
-    }
-
-    return result;
+    return ProductInfo.toList(products);
   }
 
   private static boolean isStringEmpty(String str) {

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
@@ -6,12 +6,17 @@ import com.yjjjwww.yunmarket.exception.CustomException;
 import com.yjjjwww.yunmarket.exception.ErrorCode;
 import com.yjjjwww.yunmarket.product.entity.Category;
 import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.product.model.ProductInfo;
 import com.yjjjwww.yunmarket.product.model.ProductRegisterServiceForm;
 import com.yjjjwww.yunmarket.product.repository.CategoryRepository;
 import com.yjjjwww.yunmarket.product.repository.ProductRepository;
 import com.yjjjwww.yunmarket.seller.entity.Seller;
 import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -51,6 +56,28 @@ public class ProductServiceImpl implements ProductService {
         .build();
 
     productRepository.save(product);
+  }
+
+  @Override
+  public List<ProductInfo> getLatestProducts(Integer page, Integer size) {
+    Pageable pageable = PageRequest.of(page - 1, size);
+    List<Product> products = productRepository.findAllByOrderByCreatedDateDesc(pageable);
+
+    List<ProductInfo> result = new ArrayList<>();
+
+    for (Product product : products) {
+      ProductInfo productInfo = ProductInfo.builder()
+          .name(product.getName())
+          .price(product.getPrice())
+          .description(product.getDescription())
+          .quantity(product.getQuantity())
+          .image(product.getImage())
+          .categoryName(product.getCategory().getName())
+          .build();
+      result.add(productInfo);
+    }
+
+    return result;
   }
 
   private static boolean isStringEmpty(String str) {

--- a/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
@@ -2,20 +2,27 @@ package com.yjjjwww.yunmarket.product.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yjjjwww.yunmarket.common.UserType;
 import com.yjjjwww.yunmarket.config.JwtTokenProvider;
 import com.yjjjwww.yunmarket.exception.CustomException;
 import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.product.model.ProductInfo;
 import com.yjjjwww.yunmarket.product.model.ProductRegisterForm;
 import com.yjjjwww.yunmarket.product.service.ProductService;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -24,6 +31,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
 @SpringBootTest
@@ -187,5 +195,29 @@ class ProductControllerTest {
     String code = responseJson.get("code").asText();
 
     assertEquals("CATEGORY_NOT_FOUND", code);
+  }
+
+  @Test
+  void getLatestProductsSuccess() throws Exception {
+    // given
+    List<ProductInfo> productInfos = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      productInfos.add(ProductInfo.builder().build());
+    }
+
+    // when
+    given(productService.getLatestProducts(anyInt(), anyInt())).willReturn(productInfos);
+
+    // then
+    MvcResult result = mockMvc.perform(get("/product/search/latest?page=1&size=3"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    String response = result.getResponse().getContentAsString();
+    List<ProductInfo> actualProductInfos = new ObjectMapper().readValue(response,
+        new TypeReference<>() {
+        });
+
+    assertEquals(3, actualProductInfos.size());
   }
 }

--- a/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
@@ -15,11 +15,14 @@ import com.yjjjwww.yunmarket.exception.CustomException;
 import com.yjjjwww.yunmarket.exception.ErrorCode;
 import com.yjjjwww.yunmarket.product.entity.Category;
 import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.product.model.ProductInfo;
 import com.yjjjwww.yunmarket.product.model.ProductRegisterServiceForm;
 import com.yjjjwww.yunmarket.product.repository.CategoryRepository;
 import com.yjjjwww.yunmarket.product.repository.ProductRepository;
 import com.yjjjwww.yunmarket.seller.entity.Seller;
 import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -140,5 +143,33 @@ class ProductServiceImplTest {
 
     //then
     assertEquals(ErrorCode.CATEGORY_NOT_FOUND, exception.getErrorCode());
+  }
+
+  @Test
+  void getLatestProductsSuccess() {
+    //given
+    List<Product> productList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      productList.add(Product.builder()
+          .name("상품" + i)
+          .price(i + 1)
+          .description("상품" + "i" + "설명")
+          .quantity(100 + i)
+          .image("상품" + "i" + "이미지")
+          .category(Category.builder()
+              .name("카테고리" + i)
+              .build())
+          .build());
+    }
+
+    given(productRepository.findAllByOrderByCreatedDateDesc(any())).willReturn(productList);
+
+    //when
+    List<ProductInfo> result = productService.getLatestProducts(1, 3);
+
+    //then
+    assertEquals(3, result.size());
+    assertEquals("상품1", result.get(1).getName());
+    assertEquals("카테고리1", result.get(1).getCategoryName());
   }
 }

--- a/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
@@ -162,7 +162,7 @@ class ProductServiceImplTest {
           .build());
     }
 
-    given(productRepository.findAllByOrderByCreatedDateDesc(any())).willReturn(productList);
+    given(productRepository.findAllBy(any())).willReturn(productList);
 
     //when
     List<ProductInfo> result = productService.getLatestProducts(1, 3);


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 등록된 상품을 최신순으로 조회하는 기능 구현해습니다. 해당 기능은 Role에 상관없이 요청 가능합니다.
- 상품 이름, 가격, 설명, 수량, 이미지 정보, 카테고리 이름을 보여줍니다.
- 페이징 처리를 해서 page와 size를 함께 요청을 받으면 그에 맞는 결과를 가져옵니다.
- postman으로 API 테스트 완료했고, 테스트 코드로 올바른 응답이 나오는지 확인했습니다.

**TO-BE**
- 상품 가격순, 주문 횟수 순 조회하기

### 테스트
- [x] 테스트 코드
- [x] API 테스트 