### PR TITLE
feat : 상품 낮은 가격순 조회 기능 구현

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
@@ -41,4 +41,12 @@ public class ProductController {
   ) {
     return ResponseEntity.ok(productService.getLatestProducts(page, size));
   }
+
+  @GetMapping("/search/lowestPrice")
+  public ResponseEntity<List<ProductInfo>> getLowestPriceProducts(
+      @RequestParam("page") Integer page,
+      @RequestParam("size") Integer size
+  ) {
+    return ResponseEntity.ok(productService.getLowestPriceProducts(page, size));
+  }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/repository/ProductRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/repository/ProductRepository.java
@@ -10,4 +10,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
   @Query("SELECT p FROM Product p JOIN FETCH p.category ORDER BY p.createdDate DESC")
   List<Product> findAllByOrderByCreatedDateDesc(Pageable pageable);
+
+  @Query("SELECT p FROM Product p JOIN FETCH p.category ORDER BY p.price ASC, p.createdDate DESC")
+  List<Product> findAllByOrderByPriceAscAndCreatedDateDesc(Pageable pageable);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
@@ -15,4 +15,9 @@ public interface ProductService {
    * 상품 최신순 조회
    */
   List<ProductInfo> getLatestProducts(Integer page, Integer size);
+
+  /**
+   * 상품 낮은 가격순 조회
+   */
+  List<ProductInfo> getLowestPriceProducts(Integer page, Integer size);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
@@ -80,6 +80,28 @@ public class ProductServiceImpl implements ProductService {
     return result;
   }
 
+  @Override
+  public List<ProductInfo> getLowestPriceProducts(Integer page, Integer size) {
+    Pageable pageable = PageRequest.of(page - 1, size);
+    List<Product> products = productRepository.findAllByOrderByPriceAscAndCreatedDateDesc(pageable);
+
+    List<ProductInfo> result = new ArrayList<>();
+
+    for (Product product : products) {
+      ProductInfo productInfo = ProductInfo.builder()
+          .name(product.getName())
+          .price(product.getPrice())
+          .description(product.getDescription())
+          .quantity(product.getQuantity())
+          .image(product.getImage())
+          .categoryName(product.getCategory().getName())
+          .build();
+      result.add(productInfo);
+    }
+
+    return result;
+  }
+
   private static boolean isStringEmpty(String str) {
     return str == null || str.isBlank();
   }

--- a/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
@@ -220,4 +220,28 @@ class ProductControllerTest {
 
     assertEquals(3, actualProductInfos.size());
   }
+
+  @Test
+  void getLowestPriceProductsSuccess() throws Exception {
+    // given
+    List<ProductInfo> productInfos = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      productInfos.add(ProductInfo.builder().build());
+    }
+
+    // when
+    given(productService.getLowestPriceProducts(anyInt(), anyInt())).willReturn(productInfos);
+
+    // then
+    MvcResult result = mockMvc.perform(get("/product/search/lowestPrice?page=1&size=3"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    String response = result.getResponse().getContentAsString();
+    List<ProductInfo> actualProductInfos = new ObjectMapper().readValue(response,
+        new TypeReference<>() {
+        });
+
+    assertEquals(3, actualProductInfos.size());
+  }
 }

--- a/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
@@ -172,4 +172,34 @@ class ProductServiceImplTest {
     assertEquals("상품1", result.get(1).getName());
     assertEquals("카테고리1", result.get(1).getCategoryName());
   }
+
+  @Test
+  void getLowestPriceProductsSuccess() {
+    //given
+    List<Product> productList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      productList.add(Product.builder()
+          .name("상품" + i)
+          .price(i + 1)
+          .description("상품" + "i" + "설명")
+          .quantity(100 + i)
+          .image("상품" + "i" + "이미지")
+          .category(Category.builder()
+              .name("카테고리" + i)
+              .build())
+          .build());
+    }
+
+    given(productRepository.findAllByOrderByPriceAscAndCreatedDateDesc(any())).willReturn(
+        productList);
+
+    //when
+    List<ProductInfo> result = productService.getLowestPriceProducts(1, 3);
+
+    //then
+    assertEquals(3, result.size());
+    assertEquals("상품1", result.get(1).getName());
+    assertEquals(2, result.get(1).getPrice());
+    assertEquals("카테고리1", result.get(1).getCategoryName());
+  }
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 등록된 상품을 낮은 가격순으로 조회하는 기능 구현해습니다. 해당 기능은 Role에 상관없이 요청 가능합니다.
- 상품 이름, 가격, 설명, 수량, 이미지 정보, 카테고리 이름을 보여줍니다.
- 페이징 처리를 해서 page와 size를 함께 요청을 받으면 그에 맞는 결과를 가져옵니다.
- 동일한 가격의 상품인 경우 최신순으로 조회합니다.
- postman으로 API 테스트 완료했고, 테스트 코드로 올바른 응답이 나오는지 확인했습니다.

**TO-BE**
- 상품 주문 횟수 순 조회하기

### 테스트
- [x] 테스트 코드
- [x] API 테스트 