### PR TITLE
feat : 상품 검색하기 기능 구현

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
@@ -57,4 +57,13 @@ public class ProductController {
   ) {
     return ResponseEntity.ok(productService.getMostOrderedProducts(page, size));
   }
+
+  @GetMapping("/search")
+  public ResponseEntity<List<ProductInfo>> searchProducts(
+      @RequestParam("keyword") String keyword,
+      @RequestParam("page") Integer page,
+      @RequestParam("size") Integer size
+  ) {
+    return ResponseEntity.ok(productService.searchProducts(keyword, page, size));
+  }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/entity/Category.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/entity/Category.java
@@ -14,6 +14,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -27,6 +29,7 @@ public class Category {
   private Long id;
 
   @Column(unique = true)
+  @Field(type = FieldType.Text)
   String name;
 
   @OneToMany(mappedBy = "category", fetch = FetchType.EAGER)

--- a/src/main/java/com/yjjjwww/yunmarket/product/entity/ProductDocument.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/entity/ProductDocument.java
@@ -25,14 +25,14 @@ public class ProductDocument {
   private String name;
 
   private String categoryName;
-  private Integer price;
+  private int price;
 
   @Field(type = FieldType.Text, analyzer = "ngram_analyzer")
   private String description;
   private Integer quantity;
   private String image;
   private Integer orderedCnt;
-  boolean deletedYn;
+  private boolean deletedYn;
 
   public static ProductDocument from(Product product) {
     return ProductDocument.builder()

--- a/src/main/java/com/yjjjwww/yunmarket/product/entity/ProductDocument.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/entity/ProductDocument.java
@@ -1,0 +1,50 @@
+package com.yjjjwww.yunmarket.product.entity;
+
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+@Document(indexName = "products")
+@Setting(settingPath = "elastic/product-setting.json")
+public class ProductDocument {
+
+  @Id
+  private Long id;
+
+  @Field(type = FieldType.Text, analyzer = "ngram_analyzer")
+  private String name;
+
+  private String categoryName;
+  private Integer price;
+
+  @Field(type = FieldType.Text, analyzer = "ngram_analyzer")
+  private String description;
+  private Integer quantity;
+  private String image;
+  private Integer orderedCnt;
+  boolean deletedYn;
+
+  public static ProductDocument from(Product product) {
+    return ProductDocument.builder()
+        .id(product.getId())
+        .categoryName(product.getCategory().getName())
+        .name(product.getName())
+        .price(product.getPrice())
+        .description(product.getDescription())
+        .quantity(product.getQuantity())
+        .image(product.getImage())
+        .orderedCnt(product.orderedCnt)
+        .deletedYn(product.isDeletedYn())
+        .build();
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/product/model/ProductInfo.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/model/ProductInfo.java
@@ -1,6 +1,7 @@
 package com.yjjjwww.yunmarket.product.model;
 
 import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.product.entity.ProductDocument;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -30,6 +31,19 @@ public class ProductInfo {
             .quantity(product.getQuantity())
             .image(product.getImage())
             .categoryName(product.getCategory().getName())
+            .build())
+        .collect(Collectors.toList());
+  }
+
+  public static List<ProductInfo> toListFromDocument(List<ProductDocument> products) {
+    return products.stream()
+        .map(product -> ProductInfo.builder()
+            .name(product.getName())
+            .price(product.getPrice())
+            .description(product.getDescription())
+            .quantity(product.getQuantity())
+            .image(product.getImage())
+            .categoryName(product.getCategoryName())
             .build())
         .collect(Collectors.toList());
   }

--- a/src/main/java/com/yjjjwww/yunmarket/product/repository/ElasticSearchProductRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/repository/ElasticSearchProductRepository.java
@@ -6,7 +6,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
-public interface ElasticSearchProductRepository extends ElasticsearchRepository<ProductDocument, Long> {
+public interface ElasticSearchProductRepository extends
+    ElasticsearchRepository<ProductDocument, Long> {
 
   @Query("{\"bool\":{\"must\":{\"multi_match\":{\"query\":\"?0\",\"fields\":[\"name\", \"description\"]}}}}")
   List<ProductDocument> findByNameOrDescription(String keyword, Pageable pageable);

--- a/src/main/java/com/yjjjwww/yunmarket/product/repository/ElasticSearchProductRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/repository/ElasticSearchProductRepository.java
@@ -1,0 +1,13 @@
+package com.yjjjwww.yunmarket.product.repository;
+
+import com.yjjjwww.yunmarket.product.entity.ProductDocument;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.annotations.Query;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface ElasticSearchProductRepository extends ElasticsearchRepository<ProductDocument, Long> {
+
+  @Query("{\"bool\":{\"must\":{\"multi_match\":{\"query\":\"?0\",\"fields\":[\"name\", \"description\"]}}}}")
+  List<ProductDocument> findByNameOrDescription(String keyword, Pageable pageable);
+}

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
@@ -25,4 +25,9 @@ public interface ProductService {
    * 상품 낮은 가격순 조회
    */
   List<ProductInfo> getMostOrderedProducts(Integer page, Integer size);
+
+  /**
+   * 상품 검색
+   */
+  List<ProductInfo> searchProducts(String name, Integer page, Integer size);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
@@ -6,9 +6,11 @@ import com.yjjjwww.yunmarket.exception.CustomException;
 import com.yjjjwww.yunmarket.exception.ErrorCode;
 import com.yjjjwww.yunmarket.product.entity.Category;
 import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.product.entity.ProductDocument;
 import com.yjjjwww.yunmarket.product.model.ProductInfo;
 import com.yjjjwww.yunmarket.product.model.ProductRegisterServiceForm;
 import com.yjjjwww.yunmarket.product.repository.CategoryRepository;
+import com.yjjjwww.yunmarket.product.repository.ElasticSearchProductRepository;
 import com.yjjjwww.yunmarket.product.repository.ProductRepository;
 import com.yjjjwww.yunmarket.seller.entity.Seller;
 import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
@@ -26,6 +28,7 @@ public class ProductServiceImpl implements ProductService {
   private final JwtTokenProvider provider;
   private final SellerRepository sellerRepository;
   private final ProductRepository productRepository;
+  private final ElasticSearchProductRepository elasticSearchProductRepository;
   private final CategoryRepository categoryRepository;
 
   @Override
@@ -56,6 +59,7 @@ public class ProductServiceImpl implements ProductService {
         .build();
 
     productRepository.save(product);
+    elasticSearchProductRepository.save(ProductDocument.from(product));
   }
 
   @Override
@@ -83,6 +87,14 @@ public class ProductServiceImpl implements ProductService {
     List<Product> products = productRepository.findAllBy(pageable);
 
     return ProductInfo.toList(products);
+  }
+
+  @Override
+  public List<ProductInfo> searchProducts(String keyword, Integer page, Integer size) {
+    Pageable pageable = PageRequest.of(page - 1, size);
+    List<ProductDocument> products = elasticSearchProductRepository.findByNameOrDescription(keyword, pageable);
+
+    return ProductInfo.toListFromDocument(products);
   }
 
   private static boolean isStringEmpty(String str) {

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
@@ -92,7 +92,8 @@ public class ProductServiceImpl implements ProductService {
   @Override
   public List<ProductInfo> searchProducts(String keyword, Integer page, Integer size) {
     Pageable pageable = PageRequest.of(page - 1, size);
-    List<ProductDocument> products = elasticSearchProductRepository.findByNameOrDescription(keyword, pageable);
+    List<ProductDocument> products = elasticSearchProductRepository.findByNameOrDescription(keyword,
+        pageable);
 
     return ProductInfo.toListFromDocument(products);
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,5 +5,8 @@ spring.datasource.password=yjw202020@
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
+spring.data.elasticsearch.cluster-name=elasticsearch
+spring.data.elasticsearch.cluster-nodes=localhost:9200
+spring.main.allow-bean-definition-overriding=true
 
 jwt.secret.key=yunmarket1234

--- a/src/main/resources/elasitc/product-setting.json
+++ b/src/main/resources/elasitc/product-setting.json
@@ -1,0 +1,42 @@
+{
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "ngram_analyzer": {
+          "type": "custom",
+          "tokenizer": "ngram_tokenizer",
+          "filter": ["lowercase"]
+        }
+      },
+      "tokenizer": {
+        "ngram_tokenizer": {
+          "type": "ngram",
+          "min_gram": 2,
+          "max_gram": 10,
+          "token_chars": ["letter", "digit"]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "id": {"type": "long"},
+      "name": {
+        "type": "text",
+        "analyzer": "ngram_analyzer",
+        "search_analyzer": "standard"
+      },
+      "categoryName": {"type": "text"},
+      "price": {"type": "integer"},
+      "description": {
+        "type": "text",
+        "analyzer": "ngram_analyzer",
+        "search_analyzer": "standard"
+      },
+      "quantity": {"type": "integer"},
+      "image": {"type": "text"},
+      "orderedCnt": {"type": "integer"},
+      "deletedYn": {"type": "boolean"}
+    }
+  }
+}

--- a/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
@@ -268,4 +268,28 @@ class ProductControllerTest {
 
     assertEquals(3, actualProductInfos.size());
   }
+
+  @Test
+  void searchProductsSuccess() throws Exception {
+    // given
+    List<ProductInfo> productInfos = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      productInfos.add(ProductInfo.builder().build());
+    }
+
+    // when
+    given(productService.searchProducts(anyString(), anyInt(), anyInt())).willReturn(productInfos);
+
+    // then
+    MvcResult result = mockMvc.perform(get("/product/search?keyword=product&page=1&size=3"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    String response = result.getResponse().getContentAsString();
+    List<ProductInfo> actualProductInfos = new ObjectMapper().readValue(response,
+        new TypeReference<>() {
+        });
+
+    assertEquals(3, actualProductInfos.size());
+  }
 }

--- a/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
@@ -15,9 +15,11 @@ import com.yjjjwww.yunmarket.exception.CustomException;
 import com.yjjjwww.yunmarket.exception.ErrorCode;
 import com.yjjjwww.yunmarket.product.entity.Category;
 import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.product.entity.ProductDocument;
 import com.yjjjwww.yunmarket.product.model.ProductInfo;
 import com.yjjjwww.yunmarket.product.model.ProductRegisterServiceForm;
 import com.yjjjwww.yunmarket.product.repository.CategoryRepository;
+import com.yjjjwww.yunmarket.product.repository.ElasticSearchProductRepository;
 import com.yjjjwww.yunmarket.product.repository.ProductRepository;
 import com.yjjjwww.yunmarket.seller.entity.Seller;
 import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
@@ -38,6 +40,9 @@ class ProductServiceImplTest {
 
   @Mock
   private ProductRepository productRepository;
+
+  @Mock
+  private ElasticSearchProductRepository elasticSearchProductRepository;
 
   @Mock
   private CategoryRepository categoryRepository;
@@ -225,6 +230,34 @@ class ProductServiceImplTest {
 
     //when
     List<ProductInfo> result = productService.getMostOrderedProducts(1, 3);
+
+    //then
+    assertEquals(3, result.size());
+    assertEquals("상품1", result.get(1).getName());
+    assertEquals(2, result.get(1).getPrice());
+    assertEquals("카테고리1", result.get(1).getCategoryName());
+  }
+
+  @Test
+  void searchProductsSuccess() {
+    //given
+    List<ProductDocument> productList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      productList.add(ProductDocument.builder()
+          .name("상품" + i)
+          .price(i + 1)
+          .description("상품" + i + "설명")
+          .quantity(100 + i)
+          .image("상품" + i + "이미지")
+          .categoryName("카테고리" + i)
+          .build());
+    }
+
+    given(elasticSearchProductRepository.findByNameOrDescription(anyString(), any())).willReturn(
+        productList);
+
+    //when
+    List<ProductInfo> result = productService.searchProducts("상품", 1, 3);
 
     //then
     assertEquals(3, result.size());


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 키워드를 받으면 관련 상품을 검색하는 기능 구현했습니다. 해당 기능은 Role에 상관없이 요청 가능합니다.
- ElasticSearch를 사용했습니다. 상품 이름, 상품 설명에 받은 키워드가 들어있으면 해당 상품들이 조회됩니다.
- ElasticSearch에 저장하기 위한 ProductDocument를 생성했습니다.
- 상품 등록시 mysql db, elasticsearch에 해당 상품이 저장됩니다.
- 페이징 처리를 해서 page와 size를 함께 요청을 받으면 그에 맞는 결과를 가져옵니다.
- postman으로 API 테스트 완료했고, 테스트 코드로 올바른 응답이 나오는지 확인했습니다.

**TO-BE**
- 상품 조회하기(최신순, 가격순, 주문 횟수 많은 순) Pageable를 이용한 요청으로 코드 리팩토링

### 테스트
- [x] 테스트 코드
- [x] API 테스트 