### PR TITLE
feat : 상품 상세 정보 불러오기

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
+++ b/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
   INVALID_PRODUCT_REGISTER(HttpStatus.BAD_REQUEST, "상품 등록 내용을 확인해주세요."),
   USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."),
+  PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
   CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "카테고리를 찾을 수 없습니다."),
   LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "아이디나 패스워드를 확인해 주세요."),
   INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자리에 숫자, 문자, 특수문자 각각 1개 이상 포함해야 합니다."),

--- a/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -47,5 +48,12 @@ public class ProductController {
       @RequestParam("size") Integer size
   ) {
     return ResponseEntity.ok(productService.searchProducts(keyword, page, size));
+  }
+
+  @GetMapping("/info/{id}")
+  public ResponseEntity<ProductInfo> getProductInfo(
+      @PathVariable long id
+  ) {
+    return ResponseEntity.ok(productService.getProductInfo(id));
   }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/model/ProductInfo.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/model/ProductInfo.java
@@ -16,8 +16,9 @@ import org.springframework.data.domain.Page;
 @AllArgsConstructor
 public class ProductInfo {
 
+  private Long id;
   private String name;
-  private Integer price;
+  private int price;
   private String description;
   private Integer quantity;
   private String image;
@@ -26,6 +27,7 @@ public class ProductInfo {
   public static List<ProductInfo> toList(Page<Product> products) {
     return products.stream()
         .map(product -> ProductInfo.builder()
+            .id(product.getId())
             .name(product.getName())
             .price(product.getPrice())
             .description(product.getDescription())
@@ -39,6 +41,7 @@ public class ProductInfo {
   public static List<ProductInfo> toListFromDocument(List<ProductDocument> products) {
     return products.stream()
         .map(product -> ProductInfo.builder()
+            .id(product.getId())
             .name(product.getName())
             .price(product.getPrice())
             .description(product.getDescription())
@@ -47,5 +50,17 @@ public class ProductInfo {
             .categoryName(product.getCategoryName())
             .build())
         .collect(Collectors.toList());
+  }
+
+  public static ProductInfo from(Product product) {
+    return ProductInfo.builder()
+        .id(product.getId())
+        .name(product.getName())
+        .price(product.getPrice())
+        .description(product.getDescription())
+        .quantity(product.getQuantity())
+        .image(product.getImage())
+        .categoryName(product.getCategory().getName())
+        .build();
   }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
@@ -21,4 +21,9 @@ public interface ProductService {
    * 상품 검색
    */
   List<ProductInfo> searchProducts(String name, Integer page, Integer size);
+
+  /**
+   * 상품 상세 정보 불러오기
+   */
+  ProductInfo getProductInfo(Long id);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
@@ -78,6 +78,14 @@ public class ProductServiceImpl implements ProductService {
     return ProductInfo.toListFromDocument(products);
   }
 
+  @Override
+  public ProductInfo getProductInfo(Long id) {
+    Product product = productRepository.findById(id)
+        .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+    return ProductInfo.from(product);
+  }
+
   private static boolean isStringEmpty(String str) {
     return str == null || str.isBlank();
   }

--- a/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
@@ -3,6 +3,7 @@ package com.yjjjwww.yunmarket.product.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
@@ -300,5 +301,46 @@ class ProductControllerTest {
         });
 
     assertEquals(3, actualProductInfos.size());
+  }
+
+  @Test
+  void getProductInfoSuccess() throws Exception {
+    //given
+    ProductInfo product = ProductInfo.builder()
+        .id(1L)
+        .name("상품 이름")
+        .price(1000)
+        .description("상품 설명")
+        .quantity(30)
+        .image("이미지 주소")
+        .categoryName("상품 카테고리")
+        .build();
+
+    //when
+    given(productService.getProductInfo(anyLong())).willReturn(product);
+
+    //then
+    mockMvc.perform(get("/product/info/1"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void getProductInfoFail_PRODUCT_NOT_FOUND() throws Exception {
+    //given
+
+    //when
+    doThrow(new CustomException(ErrorCode.PRODUCT_NOT_FOUND))
+        .when(productService)
+        .getProductInfo(anyLong());
+    //when
+    //then
+    ResultActions result = mockMvc.perform(get("/product/info/1"));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("PRODUCT_NOT_FOUND", code);
   }
 }

--- a/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
@@ -278,4 +278,42 @@ class ProductServiceImplTest {
     assertEquals(2, result.get(1).getPrice());
     assertEquals("카테고리1", result.get(1).getCategoryName());
   }
+
+  @Test
+  void getProductInfoSuccess() {
+    //given
+    Product product = Product.builder()
+        .id(1L)
+        .name("상품 이름")
+        .price(1000)
+        .description("상품 설명")
+        .quantity(30)
+        .image("이미지 주소")
+        .category(Category.builder()
+            .id(1L)
+            .name("카테고리 이름")
+            .build())
+        .build();
+
+    given(productRepository.findById(anyLong())).willReturn(Optional.ofNullable(product));
+
+    //when
+    ProductInfo result = productService.getProductInfo(1L);
+
+    //then
+    assertEquals("상품 이름", result.getName());
+    assertEquals(1000, result.getPrice());
+    assertEquals("카테고리 이름", result.getCategoryName());
+  }
+
+  @Test
+  void getProductInfoFail_PRODUCT_NOT_FOUND() {
+    //given
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> productService.getProductInfo(1L));
+
+    //then
+    assertEquals(ErrorCode.PRODUCT_NOT_FOUND, exception.getErrorCode());
+  }
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 상품 id를 받으면 상품 상세 정보를 불러오는 기능 구현했습니다. 해당 기능은 Role에 상관없이 요청 가능합니다.
- 상품이 존재할 경우 해당 상품의 id, 이름, 가격, 설명, 수량, 이미지, 카테고리 이름을 가져오고, 상품이 존재하지 않을 경우 Custom Error가 발생합니다.
- postman으로 API 테스트 완료했고, 테스트 코드로 올바른 응답이 나오는지 확인했습니다.

**TO-BE**
- 장바구니 기능 구현

### 테스트
- [x] 테스트 코드
- [x] API 테스트 