### PR TITLE
feat : 장바구니 담기 기능 구현

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/cart/controller/CartController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/controller/CartController.java
@@ -1,0 +1,33 @@
+package com.yjjjwww.yunmarket.cart.controller;
+
+import com.yjjjwww.yunmarket.cart.model.AddCartForm;
+import com.yjjjwww.yunmarket.cart.service.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/cart")
+public class CartController {
+
+  private final CartService cartService;
+
+  private static final String TOKEN_HEADER = "Authorization";
+  private static final String ADD_CART_SUCCESS = "장바구니 추가 완료";
+
+  @PostMapping
+  @PreAuthorize("hasRole('CUSTOMER')")
+  public ResponseEntity<String> registerProduct(
+      @RequestHeader(name = TOKEN_HEADER) String token,
+      @RequestBody AddCartForm form
+  ) {
+    cartService.addCart(form);
+    return ResponseEntity.ok(ADD_CART_SUCCESS);
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/cart/controller/CartController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/controller/CartController.java
@@ -3,6 +3,7 @@ package com.yjjjwww.yunmarket.cart.controller;
 import com.yjjjwww.yunmarket.cart.model.AddCartForm;
 import com.yjjjwww.yunmarket.cart.service.CartService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,13 +19,12 @@ public class CartController {
 
   private final CartService cartService;
 
-  private static final String TOKEN_HEADER = "Authorization";
   private static final String ADD_CART_SUCCESS = "장바구니 추가 완료";
 
   @PostMapping
   @PreAuthorize("hasRole('CUSTOMER')")
   public ResponseEntity<String> registerProduct(
-      @RequestHeader(name = TOKEN_HEADER) String token,
+      @RequestHeader(name = HttpHeaders.AUTHORIZATION) String token,
       @RequestBody AddCartForm form
   ) {
     cartService.addCart(token, form);

--- a/src/main/java/com/yjjjwww/yunmarket/cart/controller/CartController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/controller/CartController.java
@@ -27,7 +27,7 @@ public class CartController {
       @RequestHeader(name = TOKEN_HEADER) String token,
       @RequestBody AddCartForm form
   ) {
-    cartService.addCart(form);
+    cartService.addCart(token, form);
     return ResponseEntity.ok(ADD_CART_SUCCESS);
   }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/cart/entity/Cart.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/entity/Cart.java
@@ -1,0 +1,39 @@
+package com.yjjjwww.yunmarket.cart.entity;
+
+import com.yjjjwww.yunmarket.customer.entity.Customer;
+import com.yjjjwww.yunmarket.product.entity.Product;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+@Entity
+public class Cart {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "customer_id")
+  @ToString.Exclude
+  private Customer customer;
+
+  @ManyToOne
+  @JoinColumn(name = "product_id")
+  @ToString.Exclude
+  private Product product;
+
+  private Integer quantity;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/cart/model/AddCartForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/model/AddCartForm.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AddCartForm {
 
-  private Long customerId;
   private Long productId;
   private Integer quantity;
 }

--- a/src/main/java/com/yjjjwww/yunmarket/cart/model/AddCartForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/model/AddCartForm.java
@@ -1,0 +1,17 @@
+package com.yjjjwww.yunmarket.cart.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddCartForm {
+
+  private Long customerId;
+  private Long productId;
+  private Integer quantity;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/cart/repository/CartRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/repository/CartRepository.java
@@ -1,0 +1,10 @@
+package com.yjjjwww.yunmarket.cart.repository;
+
+import com.yjjjwww.yunmarket.cart.entity.Cart;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+
+  Optional<Cart> findByCustomerIdAndProductId(Long customerId, Long productId);
+}

--- a/src/main/java/com/yjjjwww/yunmarket/cart/service/CartService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/service/CartService.java
@@ -1,0 +1,11 @@
+package com.yjjjwww.yunmarket.cart.service;
+
+import com.yjjjwww.yunmarket.cart.model.AddCartForm;
+
+public interface CartService {
+
+  /**
+   * 장바구니 추가
+   */
+  void addCart(AddCartForm form);
+}

--- a/src/main/java/com/yjjjwww/yunmarket/cart/service/CartService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/service/CartService.java
@@ -7,5 +7,5 @@ public interface CartService {
   /**
    * 장바구니 추가
    */
-  void addCart(AddCartForm form);
+  void addCart(String token, AddCartForm form);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/service/CartServiceImpl.java
@@ -1,0 +1,68 @@
+package com.yjjjwww.yunmarket.cart.service;
+
+import com.yjjjwww.yunmarket.cart.entity.Cart;
+import com.yjjjwww.yunmarket.cart.model.AddCartForm;
+import com.yjjjwww.yunmarket.cart.repository.CartRepository;
+import com.yjjjwww.yunmarket.customer.entity.Customer;
+import com.yjjjwww.yunmarket.customer.repository.CustomerRepository;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.product.repository.ProductRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CartServiceImpl implements CartService {
+
+  private final CustomerRepository customerRepository;
+  private final ProductRepository productRepository;
+  private final CartRepository cartRepository;
+
+  @Override
+  public void addCart(AddCartForm form) {
+
+    Customer customer = customerRepository.findById(form.getCustomerId())
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+    Product product = productRepository.findById(form.getProductId())
+        .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+    Optional<Cart> optionalExistCart = cartRepository.findByCustomerIdAndProductId(
+        form.getCustomerId(),
+        form.getProductId());
+
+    if (optionalExistCart.isPresent()) {
+      Cart existCart = optionalExistCart.get();
+
+      Integer totalQuantity = existCart.getQuantity() + form.getQuantity();
+
+      if (!checkQuantity(product.getQuantity(), totalQuantity)) {
+        throw new CustomException(ErrorCode.NOT_ENOUGH_QUANTITY);
+      }
+
+      existCart.setQuantity(totalQuantity);
+
+      cartRepository.save(existCart);
+    } else {
+
+      if (!checkQuantity(product.getQuantity(), form.getQuantity())) {
+        throw new CustomException(ErrorCode.NOT_ENOUGH_QUANTITY);
+      }
+
+      Cart cart = Cart.builder()
+          .customer(customer)
+          .product(product)
+          .quantity(form.getQuantity())
+          .build();
+
+      cartRepository.save(cart);
+    }
+  }
+
+  private static boolean checkQuantity(Integer productQuantity, Integer cartQuantity) {
+    return productQuantity >= cartQuantity;
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/service/CartServiceImpl.java
@@ -3,6 +3,8 @@ package com.yjjjwww.yunmarket.cart.service;
 import com.yjjjwww.yunmarket.cart.entity.Cart;
 import com.yjjjwww.yunmarket.cart.model.AddCartForm;
 import com.yjjjwww.yunmarket.cart.repository.CartRepository;
+import com.yjjjwww.yunmarket.common.UserVo;
+import com.yjjjwww.yunmarket.config.JwtTokenProvider;
 import com.yjjjwww.yunmarket.customer.entity.Customer;
 import com.yjjjwww.yunmarket.customer.repository.CustomerRepository;
 import com.yjjjwww.yunmarket.exception.CustomException;
@@ -20,18 +22,20 @@ public class CartServiceImpl implements CartService {
   private final CustomerRepository customerRepository;
   private final ProductRepository productRepository;
   private final CartRepository cartRepository;
+  private final JwtTokenProvider provider;
 
   @Override
-  public void addCart(AddCartForm form) {
+  public void addCart(String token, AddCartForm form) {
+    UserVo vo = provider.getUserVo(token);
 
-    Customer customer = customerRepository.findById(form.getCustomerId())
+    Customer customer = customerRepository.findById(vo.getId())
         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
     Product product = productRepository.findById(form.getProductId())
         .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
     Optional<Cart> optionalExistCart = cartRepository.findByCustomerIdAndProductId(
-        form.getCustomerId(),
+        vo.getId(),
         form.getProductId());
 
     if (optionalExistCart.isPresent()) {

--- a/src/main/java/com/yjjjwww/yunmarket/customer/entity/Customer.java
+++ b/src/main/java/com/yjjjwww/yunmarket/customer/entity/Customer.java
@@ -1,16 +1,22 @@
 package com.yjjjwww.yunmarket.customer.entity;
 
+import com.yjjjwww.yunmarket.cart.entity.Cart;
 import com.yjjjwww.yunmarket.entity.BaseEntity;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @EqualsAndHashCode(callSuper = true)
 @AllArgsConstructor
@@ -25,11 +31,15 @@ public class Customer extends BaseEntity {
   private Long id;
 
   @Column(unique = true)
-  String email;
+  private String email;
 
-  String password;
-  String phone;
-  String address;
-  Integer point;
-  boolean deletedYn;
+  private String password;
+  private String phone;
+  private String address;
+  private Integer point;
+  private boolean deletedYn;
+
+  @OneToMany(mappedBy = "customer", fetch = FetchType.EAGER)
+  @ToString.Exclude
+  private List<Cart> cartList = new ArrayList<>();
 }

--- a/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
+++ b/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
   INVALID_PRODUCT_REGISTER(HttpStatus.BAD_REQUEST, "상품 등록 내용을 확인해주세요."),
   USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."),
   PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
+  NOT_ENOUGH_QUANTITY(HttpStatus.BAD_REQUEST, "수량이 부족합니다."),
   CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "카테고리를 찾을 수 없습니다."),
   LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "아이디나 패스워드를 확인해 주세요."),
   INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자리에 숫자, 문자, 특수문자 각각 1개 이상 포함해야 합니다."),

--- a/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
@@ -6,6 +6,7 @@ import com.yjjjwww.yunmarket.product.service.ProductService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,14 +24,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProductController {
 
   private final ProductService productService;
-  public static final String TOKEN_HEADER = "Authorization";
 
   private static final String REGISTER_PRODUCT_SUCCESS = "상품 등록 완료";
 
   @PostMapping
   @PreAuthorize("hasRole('SELLER')")
   public ResponseEntity<String> registerProduct(
-      @RequestHeader(name = TOKEN_HEADER) String token,
+      @RequestHeader(name = HttpHeaders.AUTHORIZATION) String token,
       @RequestBody ProductRegisterForm productRegisterForm) {
     productService.register(token, productRegisterForm.toServiceForm());
     return ResponseEntity.ok(REGISTER_PRODUCT_SUCCESS);

--- a/src/test/java/com/yjjjwww/yunmarket/cart/controller/CartControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/cart/controller/CartControllerTest.java
@@ -1,0 +1,176 @@
+package com.yjjjwww.yunmarket.cart.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yjjjwww.yunmarket.cart.model.AddCartForm;
+import com.yjjjwww.yunmarket.cart.service.CartService;
+import com.yjjjwww.yunmarket.common.UserType;
+import com.yjjjwww.yunmarket.config.JwtTokenProvider;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CartControllerTest {
+
+  @MockBean
+  private CartService cartService;
+
+  @MockBean
+  private JwtTokenProvider provider;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  @WithMockUser(roles = "CUSTOMER")
+  void addCartSuccess() throws Exception {
+    //given
+    AddCartForm form = AddCartForm.builder()
+        .productId(1L)
+        .quantity(30)
+        .build();
+
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.CUSTOMER);
+
+    //when
+    //then
+    mockMvc.perform(post("/cart")
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @WithMockUser(roles = "SELLER")
+  void addCartFail_SELLER_CANNOT_ADD_CART() throws Exception {
+    //given
+    AddCartForm form = AddCartForm.builder()
+        .productId(1L)
+        .quantity(30)
+        .build();
+
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.SELLER);
+
+    //when
+    //then
+    mockMvc.perform(post("/cart")
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isForbidden())
+        .andDo(print());
+  }
+
+  @Test
+  @WithMockUser(roles = "CUSTOMER")
+  void addCartFail_USER_NOT_FOUND() throws Exception {
+    //given
+    AddCartForm form = AddCartForm.builder()
+        .productId(1L)
+        .quantity(30)
+        .build();
+
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.CUSTOMER);
+
+    doThrow(new CustomException(ErrorCode.USER_NOT_FOUND))
+        .when(cartService)
+        .addCart(anyString(), any());
+
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/cart")
+        .header("Authorization", "Bearer " + token)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("USER_NOT_FOUND", code);
+  }
+
+  @Test
+  @WithMockUser(roles = "CUSTOMER")
+  void addCartFail_PRODUCT_NOT_FOUND() throws Exception {
+    //given
+    AddCartForm form = AddCartForm.builder()
+        .productId(1L)
+        .quantity(30)
+        .build();
+
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.CUSTOMER);
+
+    doThrow(new CustomException(ErrorCode.PRODUCT_NOT_FOUND))
+        .when(cartService)
+        .addCart(anyString(), any());
+
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/cart")
+        .header("Authorization", "Bearer " + token)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("PRODUCT_NOT_FOUND", code);
+  }
+
+  @Test
+  @WithMockUser(roles = "CUSTOMER")
+  void addCartFail_NOT_ENOUGH_QUANTITY() throws Exception {
+    //given
+    AddCartForm form = AddCartForm.builder()
+        .productId(1L)
+        .quantity(30)
+        .build();
+
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.CUSTOMER);
+
+    doThrow(new CustomException(ErrorCode.NOT_ENOUGH_QUANTITY))
+        .when(cartService)
+        .addCart(anyString(), any());
+
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/cart")
+        .header("Authorization", "Bearer " + token)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("NOT_ENOUGH_QUANTITY", code);
+  }
+}

--- a/src/test/java/com/yjjjwww/yunmarket/cart/service/CartServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/cart/service/CartServiceImplTest.java
@@ -1,0 +1,182 @@
+package com.yjjjwww.yunmarket.cart.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.yjjjwww.yunmarket.cart.entity.Cart;
+import com.yjjjwww.yunmarket.cart.model.AddCartForm;
+import com.yjjjwww.yunmarket.cart.repository.CartRepository;
+import com.yjjjwww.yunmarket.common.UserVo;
+import com.yjjjwww.yunmarket.config.JwtTokenProvider;
+import com.yjjjwww.yunmarket.customer.entity.Customer;
+import com.yjjjwww.yunmarket.customer.repository.CustomerRepository;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.product.repository.ProductRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CartServiceImplTest {
+
+  @Mock
+  private CartRepository cartRepository;
+
+  @Mock
+  private CustomerRepository customerRepository;
+
+  @Mock
+  private ProductRepository productRepository;
+
+  @Mock
+  private JwtTokenProvider provider;
+
+  @InjectMocks
+  private CartServiceImpl cartService;
+
+  @Test
+  void addCartSuccess_NO_EXIST_CART() {
+    //given
+    AddCartForm form = AddCartForm.builder()
+        .productId(1L)
+        .quantity(30)
+        .build();
+
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    given(customerRepository.findById(anyLong())).willReturn(
+        Optional.ofNullable(Customer.builder()
+            .id(1L)
+            .build()));
+
+    given(productRepository.findById(anyLong())).willReturn(
+        Optional.ofNullable(Product.builder()
+            .quantity(100)
+            .build()));
+
+    //when
+    cartService.addCart("jwt", form);
+
+    //then
+    verify(cartRepository, times(1)).save(any(Cart.class));
+  }
+
+  @Test
+  void addCartSuccess_EXIST_CART() {
+    //given
+    AddCartForm form = AddCartForm.builder()
+        .productId(1L)
+        .quantity(30)
+        .build();
+
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    given(customerRepository.findById(anyLong())).willReturn(
+        Optional.ofNullable(Customer.builder()
+            .id(1L)
+            .build()));
+
+    given(productRepository.findById(anyLong())).willReturn(
+        Optional.ofNullable(Product.builder()
+            .id(1L)
+            .quantity(100)
+            .build()));
+
+    given(cartRepository.findByCustomerIdAndProductId(anyLong(), anyLong())).willReturn(
+        Optional.ofNullable(Cart.builder()
+            .quantity(30)
+            .build()));
+
+    //when
+    cartService.addCart("jwt", form);
+
+    //then
+    verify(cartRepository, times(1)).save(any(Cart.class));
+  }
+
+  @Test
+  void addCartFail_USER_NOT_FOUND() {
+    //given
+    AddCartForm form = AddCartForm.builder()
+        .productId(1L)
+        .quantity(30)
+        .build();
+
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> cartService.addCart("token", form));
+
+    //then
+    assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+  }
+
+  @Test
+  void addCartFail_PRODUCT_NOT_FOUND() {
+    //given
+    AddCartForm form = AddCartForm.builder()
+        .productId(1L)
+        .quantity(30)
+        .build();
+
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    given(customerRepository.findById(anyLong())).willReturn(
+        Optional.ofNullable(Customer.builder()
+            .id(1L)
+            .build()));
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> cartService.addCart("token", form));
+
+    //then
+    assertEquals(ErrorCode.PRODUCT_NOT_FOUND, exception.getErrorCode());
+  }
+
+  @Test
+  void addCartFail_NOT_ENOUGH_QUANTITY() {
+    //given
+    AddCartForm form = AddCartForm.builder()
+        .productId(1L)
+        .quantity(30)
+        .build();
+
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    given(customerRepository.findById(anyLong())).willReturn(
+        Optional.ofNullable(Customer.builder()
+            .id(1L)
+            .build()));
+
+    given(productRepository.findById(anyLong())).willReturn(
+        Optional.ofNullable(Product.builder()
+            .id(1L)
+            .quantity(10)
+            .build()));
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> cartService.addCart("token", form));
+
+    //then
+    assertEquals(ErrorCode.NOT_ENOUGH_QUANTITY, exception.getErrorCode());
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- Cart 엔티티 설정 했습니다.
- JWT 토큰에 담긴 customer Id로 Customer 조회합니다. 존재하지 않으면 Custom Error 발생합니다.
- 장바구니 담기할 때 product가 존재하는지 확인합니다. 존재하지 않으면 Custom Error 발생합니다.
- 해당 상품의 남은 수량과 장바구니에 담는 수량 비교하여 장바구니 수량이 더 많으면 Custom Error 발생합니다.
- 해당 customer Id, product Id를 가지고 있는 장바구니가 존재하는지 확인. 존재하면 해당 장바구니에서 상품 수량 추가합니다.
- postman으로 API 테스트 완료했고, 테스트 코드로 올바른 응답이 나오는지 확인했습니다.

**TO-BE**
- 장바구니 수정, 삭제

### 테스트
- [x] 테스트 코드
- [x] API 테스트 