### PR TITLE
feat : 장바구니 삭제 기능 구현

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/cart/controller/CartController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/controller/CartController.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,10 +25,11 @@ public class CartController {
 
   private static final String ADD_CART_SUCCESS = "장바구니 추가 완료";
   private static final String EDIT_CART_SUCCESS = "장바구니 수정 완료";
+  private static final String DELETE_CART_ITEM_SUCCESS = "장바구니 상품 삭제 완료";
+  private static final String DELETE_ALL_CART_SUCCESS = "삭제 완료";
 
   @PostMapping
   @PreAuthorize("hasRole('CUSTOMER')")
-
   public ResponseEntity<String> registerProduct(
       @RequestHeader(name = HttpHeaders.AUTHORIZATION) String token,
       @RequestBody AddCartForm form
@@ -43,5 +46,24 @@ public class CartController {
   ) {
     cartService.editCart(token, form);
     return ResponseEntity.ok(EDIT_CART_SUCCESS);
+  }
+
+  @DeleteMapping("/item/{id}")
+  @PreAuthorize("hasRole('CUSTOMER')")
+  public ResponseEntity<String> deleteCartItem(
+      @RequestHeader(name = HttpHeaders.AUTHORIZATION) String token,
+      @PathVariable("id") long id
+  ) {
+    cartService.deleteCartItem(token, id);
+    return ResponseEntity.ok(DELETE_CART_ITEM_SUCCESS);
+  }
+
+  @DeleteMapping("/items")
+  @PreAuthorize("hasRole('CUSTOMER')")
+  public ResponseEntity<String> deleteAllCart(
+      @RequestHeader(name = HttpHeaders.AUTHORIZATION) String token
+  ) {
+    long cnt = cartService.deleteAllCart(token);
+    return ResponseEntity.ok(cnt + "개의 상품 " + DELETE_ALL_CART_SUCCESS);
   }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/cart/repository/CartRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/repository/CartRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
   Optional<Cart> findByCustomerIdAndProductId(Long customerId, Long productId);
+
+  Long deleteByCustomerId(Long customerId);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/cart/service/CartService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/service/CartService.java
@@ -14,4 +14,14 @@ public interface CartService {
    * 장바구니 수정
    */
   void editCart(String token, EditCartForm form);
+
+  /**
+   * 장바구니 선택한 상품 삭제
+   */
+  void deleteCartItem(String token, Long productId);
+
+  /**
+   * 장바구니 전체 삭제
+   */
+  long deleteAllCart(String token);
 }

--- a/src/test/java/com/yjjjwww/yunmarket/cart/controller/CartControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/cart/controller/CartControllerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -315,5 +316,33 @@ class CartControllerTest {
     String code = responseJson.get("code").asText();
 
     assertEquals("NOT_ENOUGH_QUANTITY", code);
+  }
+
+  @Test
+  @WithMockUser(roles = "CUSTOMER")
+  void deleteCartItemSuccess() throws Exception {
+    //given
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.CUSTOMER);
+
+    //when
+    //then
+    mockMvc.perform(delete("/cart/item/1")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @WithMockUser(roles = "CUSTOMER")
+  void deleteAllCartSuccess() throws Exception {
+    //given
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.CUSTOMER);
+
+    //when
+    //then
+    mockMvc.perform(delete("/cart/items")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andDo(print());
   }
 }

--- a/src/test/java/com/yjjjwww/yunmarket/cart/service/CartServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/cart/service/CartServiceImplTest.java
@@ -340,4 +340,62 @@ class CartServiceImplTest {
     //then
     assertEquals(ErrorCode.NOT_ENOUGH_QUANTITY, exception.getErrorCode());
   }
+
+  @Test
+  void deleteCartItemSuccess() {
+    //given
+    Customer customer = Customer.builder()
+        .id(1L)
+        .build();
+
+    Product product = Product.builder()
+        .id(1L)
+        .quantity(100)
+        .build();
+
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    given(customerRepository.findById(anyLong())).willReturn(
+        Optional.ofNullable(customer));
+
+    given(productRepository.findById(anyLong())).willReturn(
+        Optional.ofNullable(product));
+
+    given(cartRepository.findByCustomerIdAndProductId(anyLong(), anyLong())).willReturn(
+        Optional.ofNullable(Cart.builder()
+            .customer(customer)
+            .product(product)
+            .quantity(100)
+            .build()));
+
+    //when
+    cartService.deleteCartItem("jwt", 1L);
+
+    //then
+    verify(cartRepository, times(1)).delete(any(Cart.class));
+  }
+
+  @Test
+  void deleteAllCartSuccess() {
+    //given
+    Customer customer = Customer.builder()
+        .id(1L)
+        .build();
+
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    given(customerRepository.findById(anyLong())).willReturn(
+        Optional.ofNullable(customer));
+
+    given(cartRepository.deleteByCustomerId(anyLong())).willReturn(3L);
+
+    //when
+    long result = cartService.deleteAllCart("jwt");
+
+    //then
+    verify(cartRepository, times(1)).deleteByCustomerId(anyLong());
+    assertEquals(3L, result);
+  }
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 장바구니 삭제 기능 구현했습니다. product id를 같이 요청을 보내서 해당 상품을 장바구니에서 삭제하는 기능과 해당 customer의 모든 장바구니를 삭제하는 기능 구현했습니다.
- JWT 토큰으로 받은 customer Id로 해당 customer가 존재하는지 확인합니다. product Id를 받으면 해당 상품이 존재하는지 확인하고, 장바구니에 customer가 해당 상품을 장바구니에 담았는지 확인합니다.
- 장바구니 전체 삭제시 몇 개의 상품이 삭제됐는지 결과를 가져옵니다.
- postman으로 API 테스트 완료했고, 테스트 코드로 올바른 응답이 나오는지 확인했습니다.

**TO-BE**
- 주문하기

### 테스트
- [x] 테스트 코드
- [x] API 테스트 