### PR TITLE
feat : 상품 주문하기 기능 구현

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/cart/repository/CartRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/cart/repository/CartRepository.java
@@ -1,6 +1,7 @@
 package com.yjjjwww.yunmarket.cart.repository;
 
 import com.yjjjwww.yunmarket.cart.entity.Cart;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
   Optional<Cart> findByCustomerIdAndProductId(Long customerId, Long productId);
 
   Long deleteByCustomerId(Long customerId);
+
+  List<Cart> findByCustomerId(Long customerId);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/transaction/controller/OrderController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/transaction/controller/OrderController.java
@@ -1,0 +1,31 @@
+package com.yjjjwww.yunmarket.transaction.controller;
+
+import com.yjjjwww.yunmarket.transaction.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/order")
+public class OrderController {
+
+  private final OrderService orderService;
+
+  private static final String ORDER_ITEMS_SUCCESS = "주문 완료";
+
+
+  @PostMapping
+  @PreAuthorize("hasRole('CUSTOMER')")
+  public ResponseEntity<String> orderItems(
+      @RequestHeader(name = HttpHeaders.AUTHORIZATION) String token
+  ) {
+    orderService.orderItems(token);
+    return ResponseEntity.ok(ORDER_ITEMS_SUCCESS);
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/transaction/entity/Ordered.java
+++ b/src/main/java/com/yjjjwww/yunmarket/transaction/entity/Ordered.java
@@ -1,0 +1,55 @@
+package com.yjjjwww.yunmarket.transaction.entity;
+
+import com.yjjjwww.yunmarket.customer.entity.Customer;
+import com.yjjjwww.yunmarket.entity.BaseEntity;
+import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.seller.entity.Seller;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+@Entity
+public class Ordered extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "customer_id")
+  @ToString.Exclude
+  private Customer customer;
+
+  @ManyToOne
+  @JoinColumn(name = "product_id")
+  @ToString.Exclude
+  private Product product;
+
+  @ManyToOne
+  @JoinColumn(name = "seller_id")
+  @ToString.Exclude
+  private Seller seller;
+
+  @ManyToOne
+  @JoinColumn(name = "transaction_id")
+  @ToString.Exclude
+  private Transaction transaction;
+
+  private Integer price;
+  private Integer quantity;
+  private Integer total;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/transaction/entity/Transaction.java
+++ b/src/main/java/com/yjjjwww/yunmarket/transaction/entity/Transaction.java
@@ -1,0 +1,48 @@
+package com.yjjjwww.yunmarket.transaction.entity;
+
+import com.yjjjwww.yunmarket.customer.entity.Customer;
+import com.yjjjwww.yunmarket.entity.BaseEntity;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+@Entity
+public class Transaction extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "customer_id")
+  @ToString.Exclude
+  private Customer customer;
+
+  @OneToMany(mappedBy = "transaction", fetch = FetchType.LAZY)
+  @ToString.Exclude
+  private List<Ordered> orderedListList = new ArrayList<>();
+
+  private LocalDateTime transactionDate;
+  private Integer transactionPrice;
+  private Integer pointUse;
+  private boolean deletedYn;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/transaction/repository/OrderedRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/transaction/repository/OrderedRepository.java
@@ -1,0 +1,8 @@
+package com.yjjjwww.yunmarket.transaction.repository;
+
+import com.yjjjwww.yunmarket.transaction.entity.Ordered;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderedRepository extends JpaRepository<Ordered, Long> {
+
+}

--- a/src/main/java/com/yjjjwww/yunmarket/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/transaction/repository/TransactionRepository.java
@@ -1,0 +1,8 @@
+package com.yjjjwww.yunmarket.transaction.repository;
+
+import com.yjjjwww.yunmarket.transaction.entity.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+
+}

--- a/src/main/java/com/yjjjwww/yunmarket/transaction/service/OrderService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/transaction/service/OrderService.java
@@ -1,0 +1,9 @@
+package com.yjjjwww.yunmarket.transaction.service;
+
+public interface OrderService {
+
+  /**
+   * 상품 주문하기
+   */
+  void orderItems(String token);
+}

--- a/src/main/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImpl.java
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
-public class OrderServiceImpl implements OrderService{
+public class OrderServiceImpl implements OrderService {
 
   private final JwtTokenProvider provider;
   private final SellerRepository sellerRepository;

--- a/src/main/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImpl.java
@@ -1,0 +1,96 @@
+package com.yjjjwww.yunmarket.transaction.service;
+
+import com.yjjjwww.yunmarket.cart.entity.Cart;
+import com.yjjjwww.yunmarket.cart.repository.CartRepository;
+import com.yjjjwww.yunmarket.common.UserVo;
+import com.yjjjwww.yunmarket.config.JwtTokenProvider;
+import com.yjjjwww.yunmarket.customer.entity.Customer;
+import com.yjjjwww.yunmarket.customer.repository.CustomerRepository;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.product.repository.ProductRepository;
+import com.yjjjwww.yunmarket.seller.entity.Seller;
+import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
+import com.yjjjwww.yunmarket.transaction.entity.Ordered;
+import com.yjjjwww.yunmarket.transaction.entity.Transaction;
+import com.yjjjwww.yunmarket.transaction.repository.OrderedRepository;
+import com.yjjjwww.yunmarket.transaction.repository.TransactionRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class OrderServiceImpl implements OrderService{
+
+  private final JwtTokenProvider provider;
+  private final SellerRepository sellerRepository;
+  private final CustomerRepository customerRepository;
+  private final CartRepository cartRepository;
+  private final ProductRepository productRepository;
+  private final OrderedRepository orderedRepository;
+  private final TransactionRepository transactionRepository;
+
+  @Override
+  @Transactional
+  public void orderItems(String token) {
+    Customer customer = getCustomerFromToken(token);
+
+    List<Cart> cartList = cartRepository.findByCustomerId(customer.getId());
+
+    if (cartList.size() == 0) {
+      throw new CustomException(ErrorCode.CART_NOT_FOUND);
+    }
+
+    List<Ordered> orderedList = new ArrayList<>();
+
+    int total = 0;
+
+    for (Cart cart : cartList) {
+      Product product = cart.getProduct();
+      Seller seller = cart.getProduct().getSeller();
+      int totalPrice = product.getPrice() * cart.getQuantity();
+
+      Ordered ordered = Ordered.builder()
+          .customer(customer)
+          .product(product)
+          .seller(seller)
+          .price(product.getPrice())
+          .quantity(cart.getQuantity())
+          .total(totalPrice)
+          .build();
+
+      orderedList.add(ordered);
+      total += totalPrice;
+    }
+
+    Transaction transaction = Transaction.builder()
+        .customer(customer)
+        .orderedListList(orderedList)
+        .transactionDate(LocalDateTime.now())
+        .transactionPrice(total)
+        .pointUse(0)
+        .build();
+
+    for (Ordered ordered : orderedList) {
+      ordered.setTransaction(transaction);
+    }
+
+    transactionRepository.save(transaction);
+    orderedRepository.saveAll(orderedList);
+    cartRepository.deleteByCustomerId(customer.getId());
+  }
+
+  private Customer getCustomerFromToken(String token) {
+    UserVo vo = provider.getUserVo(token);
+
+    Customer customer = customerRepository.findById(vo.getId())
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+    return customer;
+  }
+}

--- a/src/test/java/com/yjjjwww/yunmarket/transaction/controller/OrderControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/transaction/controller/OrderControllerTest.java
@@ -1,0 +1,91 @@
+package com.yjjjwww.yunmarket.transaction.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yjjjwww.yunmarket.common.UserType;
+import com.yjjjwww.yunmarket.config.JwtTokenProvider;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.transaction.service.OrderService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OrderControllerTest {
+
+  @MockBean
+  private OrderService orderService;
+
+  @MockBean
+  private JwtTokenProvider provider;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  @WithMockUser(roles = "CUSTOMER")
+  void orderItemsSuccess() throws Exception {
+    //given
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.CUSTOMER);
+
+    //when
+    //then
+    mockMvc.perform(post("/order")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @WithMockUser(roles = "SELLER")
+  void orderItemsFail_SELLER_CANNOT_ORDER() throws Exception {
+    //given
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.SELLER);
+
+    //when
+    //then
+    mockMvc.perform(post("/order")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isForbidden())
+        .andDo(print());
+  }
+
+  @Test
+  @WithMockUser(roles = "CUSTOMER")
+  void orderItemsFail_CART_NOT_FOUND() throws Exception {
+    //given
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.CUSTOMER);
+
+    doThrow(new CustomException(ErrorCode.CART_NOT_FOUND))
+        .when(orderService)
+        .orderItems(anyString());
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/order")
+        .header("Authorization", "Bearer " + token));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("CART_NOT_FOUND", code);
+  }
+}

--- a/src/test/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImplTest.java
@@ -1,0 +1,120 @@
+package com.yjjjwww.yunmarket.transaction.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.yjjjwww.yunmarket.cart.entity.Cart;
+import com.yjjjwww.yunmarket.cart.repository.CartRepository;
+import com.yjjjwww.yunmarket.common.UserVo;
+import com.yjjjwww.yunmarket.config.JwtTokenProvider;
+import com.yjjjwww.yunmarket.customer.entity.Customer;
+import com.yjjjwww.yunmarket.customer.repository.CustomerRepository;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.seller.entity.Seller;
+import com.yjjjwww.yunmarket.transaction.entity.Transaction;
+import com.yjjjwww.yunmarket.transaction.repository.OrderedRepository;
+import com.yjjjwww.yunmarket.transaction.repository.TransactionRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceImplTest {
+
+  @Mock
+  private JwtTokenProvider provider;
+
+  @Mock
+  private CustomerRepository customerRepository;
+
+  @Mock
+  private CartRepository cartRepository;
+
+  @Mock
+  private OrderedRepository orderedRepository;
+
+  @Mock
+  private TransactionRepository transactionRepository;
+
+  @InjectMocks
+  private OrderServiceImpl orderService;
+
+  @Test
+  void orderItemsSuccess() {
+    //given
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    given(customerRepository.findById(anyLong()))
+        .willReturn(Optional.ofNullable(Customer.builder()
+            .id(1L)
+            .build()));
+
+    List<Cart> cartList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      Seller seller = Seller.builder()
+          .id((long) i)
+          .build();
+
+      Product product = Product.builder()
+          .id((long) i)
+          .seller(seller)
+          .price(1000 + i)
+          .build();
+
+      Cart cart = Cart.builder()
+          .product(product)
+          .quantity(i + 1)
+          .build();
+
+      cartList.add(cart);
+    }
+
+    given(cartRepository.findByCustomerId(anyLong()))
+        .willReturn(cartList);
+
+    //when
+    orderService.orderItems("jwt");
+
+    //then
+    verify(transactionRepository, times(1)).save(any(Transaction.class));
+    verify(orderedRepository, times(1)).saveAll(any());
+    verify(cartRepository, times(1)).deleteByCustomerId(anyLong());
+  }
+
+  @Test
+  void orderItemsFail_CART_NOT_FOUND() {
+    //given
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    given(customerRepository.findById(anyLong()))
+        .willReturn(Optional.ofNullable(Customer.builder()
+            .id(1L)
+            .build()));
+
+    List<Cart> cartList = new ArrayList<>();
+
+    given(cartRepository.findByCustomerId(anyLong()))
+        .willReturn(cartList);
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> orderService.orderItems("token"));
+
+    //then
+    assertEquals(ErrorCode.CART_NOT_FOUND, exception.getErrorCode());
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- Ordered, Transaction 엔티티 설정했습니다.
- 주문하기 요청을 받으면 customer 장바구니 목록을 가져와서 ordered, transaction 테이블에 주문 정보를 저장합니다.
- ordered, transaction에 주문 정보 저장 후 customer 장바구니 목록 전체 삭제합니다.
- postman으로 API 테스트 완료했고, 테스트 코드로 올바른 응답이 나오는지 확인했습니다.

**TO-BE**
- 주문 정보 조회하기

### 테스트
- [x] 테스트 코드
- [x] API 테스트 