### PR TITLE
feat : 적립금 기능 구현

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
+++ b/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
   ORDERED_NOT_FOUND(HttpStatus.BAD_REQUEST, "주문 정보를 찾을 수 없습니다."),
   TRANSACTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "주문 정보를 찾을 수 없습니다."),
   NOT_ENOUGH_QUANTITY(HttpStatus.BAD_REQUEST, "수량이 부족합니다."),
+  NOT_ENOUGH_POINT(HttpStatus.BAD_REQUEST, "적립금이 부족합니다."),
   CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "카테고리를 찾을 수 없습니다."),
   LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "아이디나 패스워드를 확인해 주세요."),
   INVALID_REVIEW_FORM(HttpStatus.BAD_REQUEST, "리뷰 양식을 확인해주세요."),

--- a/src/main/java/com/yjjjwww/yunmarket/transaction/controller/OrderController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/transaction/controller/OrderController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,9 +27,10 @@ public class OrderController {
   @PostMapping
   @PreAuthorize("hasRole('CUSTOMER')")
   public ResponseEntity<String> orderItems(
-      @RequestHeader(name = HttpHeaders.AUTHORIZATION) String token
+      @RequestHeader(name = HttpHeaders.AUTHORIZATION) String token,
+      @RequestParam("point") Integer point
   ) {
-    orderService.orderItems(token);
+    orderService.orderItems(token, point);
     return ResponseEntity.ok(ORDER_ITEMS_SUCCESS);
   }
 

--- a/src/main/java/com/yjjjwww/yunmarket/transaction/service/OrderService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/transaction/service/OrderService.java
@@ -9,7 +9,7 @@ public interface OrderService {
   /**
    * 상품 주문하기
    */
-  void orderItems(String token);
+  void orderItems(String token, Integer point);
 
   /**
    * 주문 상품 전체 목록 가져오기

--- a/src/test/java/com/yjjjwww/yunmarket/transaction/controller/OrderControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/transaction/controller/OrderControllerTest.java
@@ -1,6 +1,7 @@
 package com.yjjjwww.yunmarket.transaction.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -49,7 +50,7 @@ class OrderControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/order")
+    mockMvc.perform(post("/order?point=300")
             .header("Authorization", "Bearer " + token))
         .andExpect(status().isOk())
         .andDo(print());
@@ -63,7 +64,7 @@ class OrderControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/order")
+    mockMvc.perform(post("/order?point=300")
             .header("Authorization", "Bearer " + token))
         .andExpect(status().isForbidden())
         .andDo(print());
@@ -77,10 +78,10 @@ class OrderControllerTest {
 
     doThrow(new CustomException(ErrorCode.CART_NOT_FOUND))
         .when(orderService)
-        .orderItems(anyString());
+        .orderItems(anyString(), anyInt());
     //when
     //then
-    ResultActions result = mockMvc.perform(post("/order")
+    ResultActions result = mockMvc.perform(post("/order?point=100")
         .header("Authorization", "Bearer " + token));
     result.andExpect(status().isBadRequest())
         .andDo(print());

--- a/src/test/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImplTest.java
@@ -64,6 +64,7 @@ class OrderServiceImplTest {
     given(customerRepository.findById(anyLong()))
         .willReturn(Optional.ofNullable(Customer.builder()
             .id(1L)
+            .point(1000)
             .build()));
 
     List<Cart> cartList = new ArrayList<>();
@@ -91,7 +92,7 @@ class OrderServiceImplTest {
         .willReturn(cartList);
 
     //when
-    orderService.orderItems("jwt");
+    orderService.orderItems("jwt", 300);
 
     //then
     verify(transactionRepository, times(1)).save(any(Transaction.class));
@@ -117,7 +118,7 @@ class OrderServiceImplTest {
 
     //when
     CustomException exception = assertThrows(CustomException.class,
-        () -> orderService.orderItems("token"));
+        () -> orderService.orderItems("token", 300));
 
     //then
     assertEquals(ErrorCode.CART_NOT_FOUND, exception.getErrorCode());


### PR DESCRIPTION
### 변경사항
**AS-IS**
- transaction에 적립금 사용 내역 저장, 거래 금액에서는 총 금액에서 적립금을 뺐음.
- customer 적립금은 기본 적립금에서 사용한 적립금을 뺀 뒤, 거래 금액의 1% 적립하는 방식 사용
- postman으로 API 테스트 완료했고, 테스트 코드로 올바른 응답이 나오는지 확인

**TO-BE**
- 최근 본 상품과 관련 인기 상품 불러오기

### 테스트
- [x] 테스트 코드
- [x] API 테스트 