### PR TITLE
feat : 최근 본 상품과 관련 인기 상품 불러오기

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/common/ClientUtils.java
+++ b/src/main/java/com/yjjjwww/yunmarket/common/ClientUtils.java
@@ -1,0 +1,28 @@
+package com.yjjjwww.yunmarket.common;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class ClientUtils {
+
+  public static String getIp(HttpServletRequest request) {
+    String ip = request.getHeader("X-Forwarded-For");
+
+    if (ip == null) {
+      ip = request.getHeader("Proxy-Client-IP");
+    }
+    if (ip == null) {
+      ip = request.getHeader("WL-Proxy-Client-IP");
+    }
+    if (ip == null) {
+      ip = request.getHeader("HTTP_CLIENT_IP");
+    }
+    if (ip == null) {
+      ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+    }
+    if (ip == null) {
+      ip = request.getRemoteAddr();
+    }
+
+    return ip;
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
@@ -63,9 +63,11 @@ public class ProductController {
 
   @GetMapping("/recent")
   public ResponseEntity<List<ProductInfo>> getRecentViewedProducts(
-      HttpServletRequest request
+      HttpServletRequest request,
+      @RequestParam("page") Integer page,
+      @RequestParam("size") Integer size
   ) {
     String userIp = ClientUtils.getIp(request);
-    return ResponseEntity.ok(productService.getRecentViewedProducts(userIp));
+    return ResponseEntity.ok(productService.getRecentViewedProducts(userIp, page, size));
   }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/controller/ProductController.java
@@ -1,9 +1,11 @@
 package com.yjjjwww.yunmarket.product.controller;
 
+import com.yjjjwww.yunmarket.common.ClientUtils;
 import com.yjjjwww.yunmarket.product.model.ProductInfo;
 import com.yjjjwww.yunmarket.product.model.ProductRegisterForm;
 import com.yjjjwww.yunmarket.product.service.ProductService;
 import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
@@ -52,8 +54,18 @@ public class ProductController {
 
   @GetMapping("/info/{id}")
   public ResponseEntity<ProductInfo> getProductInfo(
-      @PathVariable long id
+      @PathVariable long id,
+      HttpServletRequest request
   ) {
-    return ResponseEntity.ok(productService.getProductInfo(id));
+    String userIp = ClientUtils.getIp(request);
+    return ResponseEntity.ok(productService.getProductInfo(id, userIp));
+  }
+
+  @GetMapping("/recent")
+  public ResponseEntity<List<ProductInfo>> getRecentViewedProducts(
+      HttpServletRequest request
+  ) {
+    String userIp = ClientUtils.getIp(request);
+    return ResponseEntity.ok(productService.getRecentViewedProducts(userIp));
   }
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/entity/ProductViewHistory.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/entity/ProductViewHistory.java
@@ -1,0 +1,35 @@
+package com.yjjjwww.yunmarket.product.entity;
+
+import com.yjjjwww.yunmarket.entity.BaseEntity;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+@Entity
+public class ProductViewHistory extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @OneToOne
+  @JoinColumn(name = "product_id")
+  @ToString.Exclude
+  private Product product;
+
+  private String userIp;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/product/repository/ProductRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/repository/ProductRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 public interface ProductRepository extends PagingAndSortingRepository<Product, Long> {
 
   Page<Product> findAll(Pageable pageable);
+
+  Page<Product> findAllByCategoryId(Long categoryId, Pageable pageable);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/repository/ProductViewHistoryRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/repository/ProductViewHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.yjjjwww.yunmarket.product.repository;
+
+import com.yjjjwww.yunmarket.product.entity.ProductViewHistory;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductViewHistoryRepository extends JpaRepository<ProductViewHistory, Long> {
+
+  Optional<ProductViewHistory> findByUserIp(String userIp);
+}

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
@@ -25,5 +25,10 @@ public interface ProductService {
   /**
    * 상품 상세 정보 불러오기
    */
-  ProductInfo getProductInfo(Long id);
+  ProductInfo getProductInfo(Long id, String userIp);
+
+  /**
+   * IP 기준 최근 본 상품과 관련 인기 상품들 가져오기
+   */
+  List<ProductInfo> getRecentViewedProducts(String userIp);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductService.java
@@ -30,5 +30,5 @@ public interface ProductService {
   /**
    * IP 기준 최근 본 상품과 관련 인기 상품들 가져오기
    */
-  List<ProductInfo> getRecentViewedProducts(String userIp);
+  List<ProductInfo> getRecentViewedProducts(String userIp, Integer page, Integer size);
 }

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
@@ -109,7 +109,7 @@ public class ProductServiceImpl implements ProductService {
   }
 
   @Override
-  public List<ProductInfo> getRecentViewedProducts(String userIp) {
+  public List<ProductInfo> getRecentViewedProducts(String userIp, Integer page, Integer size) {
     Optional<ProductViewHistory> optionalProductViewHistory = productViewHistoryRepository.findByUserIp(
         userIp);
 
@@ -120,7 +120,7 @@ public class ProductServiceImpl implements ProductService {
     Product product = optionalProductViewHistory.get().getProduct();
     Long categoryId = product.getCategory().getId();
 
-    Pageable pageable = PageRequest.of(0, 4, Sort.by("orderedCnt").descending());
+    Pageable pageable = PageRequest.of(page - 1, size, Sort.by("orderedCnt").descending());
 
     Page<Product> productList = productRepository.findAllByCategoryId(categoryId, pageable);
 

--- a/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
@@ -364,10 +364,10 @@ class ProductControllerTest {
     }
 
     //when
-    given(productService.getRecentViewedProducts(anyString())).willReturn(productInfoList);
+    given(productService.getRecentViewedProducts(anyString(), anyInt(), anyInt())).willReturn(productInfoList);
 
     //then
-    mockMvc.perform(get("/product/recent"))
+    mockMvc.perform(get("/product/recent?page=1&size=5"))
         .andExpect(status().isOk());
   }
 
@@ -376,10 +376,10 @@ class ProductControllerTest {
     //given
     doThrow(new CustomException(ErrorCode.PRODUCT_NOT_FOUND))
         .when(productService)
-        .getRecentViewedProducts(anyString());
+        .getRecentViewedProducts(anyString(), anyInt(), anyInt());
     //when
     //then
-    ResultActions result = mockMvc.perform(get("/product/recent"));
+    ResultActions result = mockMvc.perform(get("/product/recent?page=1&size=5"));
     result.andExpect(status().isBadRequest())
         .andDo(print());
     String responseBody = result.andReturn().getResponse().getContentAsString();

--- a/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/controller/ProductControllerTest.java
@@ -317,7 +317,7 @@ class ProductControllerTest {
         .build();
 
     //when
-    given(productService.getProductInfo(anyLong())).willReturn(product);
+    given(productService.getProductInfo(anyLong(), any())).willReturn(product);
 
     //then
     mockMvc.perform(get("/product/info/1"))
@@ -331,10 +331,55 @@ class ProductControllerTest {
     //when
     doThrow(new CustomException(ErrorCode.PRODUCT_NOT_FOUND))
         .when(productService)
-        .getProductInfo(anyLong());
+        .getProductInfo(anyLong(), anyString());
     //when
     //then
     ResultActions result = mockMvc.perform(get("/product/info/1"));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("PRODUCT_NOT_FOUND", code);
+  }
+
+  @Test
+  void getRecentViewedProductsSuccess() throws Exception {
+    //given
+    List<ProductInfo> productInfoList = new ArrayList<>();
+
+    for (int i = 0; i < 3; i++) {
+      ProductInfo product = ProductInfo.builder()
+          .id((long) i)
+          .name("상품 이름" + i)
+          .price(1000 + i)
+          .description("상품" + i + " 설명")
+          .quantity(30 + i)
+          .image("이미지 주소")
+          .categoryName("상품 카테고리")
+          .build();
+
+      productInfoList.add(product);
+    }
+
+    //when
+    given(productService.getRecentViewedProducts(anyString())).willReturn(productInfoList);
+
+    //then
+    mockMvc.perform(get("/product/recent"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void getRecentViewedProductsFail_PRODUCT_NOT_FOUND() throws Exception {
+    //given
+    doThrow(new CustomException(ErrorCode.PRODUCT_NOT_FOUND))
+        .when(productService)
+        .getRecentViewedProducts(anyString());
+    //when
+    //then
+    ResultActions result = mockMvc.perform(get("/product/recent"));
     result.andExpect(status().isBadRequest())
         .andDo(print());
     String responseBody = result.andReturn().getResponse().getContentAsString();

--- a/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/product/service/ProductServiceImplTest.java
@@ -16,11 +16,13 @@ import com.yjjjwww.yunmarket.exception.ErrorCode;
 import com.yjjjwww.yunmarket.product.entity.Category;
 import com.yjjjwww.yunmarket.product.entity.Product;
 import com.yjjjwww.yunmarket.product.entity.ProductDocument;
+import com.yjjjwww.yunmarket.product.entity.ProductViewHistory;
 import com.yjjjwww.yunmarket.product.model.ProductInfo;
 import com.yjjjwww.yunmarket.product.model.ProductRegisterServiceForm;
 import com.yjjjwww.yunmarket.product.repository.CategoryRepository;
 import com.yjjjwww.yunmarket.product.repository.ElasticSearchProductRepository;
 import com.yjjjwww.yunmarket.product.repository.ProductRepository;
+import com.yjjjwww.yunmarket.product.repository.ProductViewHistoryRepository;
 import com.yjjjwww.yunmarket.seller.entity.Seller;
 import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
 import java.util.ArrayList;
@@ -51,6 +53,9 @@ class ProductServiceImplTest {
 
   @Mock
   private CategoryRepository categoryRepository;
+
+  @Mock
+  private ProductViewHistoryRepository productViewHistoryRepository;
 
   @Mock
   private JwtTokenProvider provider;
@@ -295,10 +300,14 @@ class ProductServiceImplTest {
             .build())
         .build();
 
-    given(productRepository.findById(anyLong())).willReturn(Optional.ofNullable(product));
+    given(productRepository.findById(anyLong()))
+        .willReturn(Optional.ofNullable(product));
+
+    given(productViewHistoryRepository.findByUserIp(anyString()))
+        .willReturn(Optional.ofNullable(ProductViewHistory.builder().build()));
 
     //when
-    ProductInfo result = productService.getProductInfo(1L);
+    ProductInfo result = productService.getProductInfo(1L, "ip");
 
     //then
     assertEquals("상품 이름", result.getName());
@@ -311,7 +320,7 @@ class ProductServiceImplTest {
     //given
     //when
     CustomException exception = assertThrows(CustomException.class,
-        () -> productService.getProductInfo(1L));
+        () -> productService.getProductInfo(1L, anyString()));
 
     //then
     assertEquals(ErrorCode.PRODUCT_NOT_FOUND, exception.getErrorCode());

--- a/src/test/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImplTest.java
@@ -109,6 +109,7 @@ class OrderServiceImplTest {
     given(customerRepository.findById(anyLong()))
         .willReturn(Optional.ofNullable(Customer.builder()
             .id(1L)
+            .point(300)
             .build()));
 
     List<Cart> cartList = new ArrayList<>();

--- a/src/test/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImplTest.java
@@ -17,6 +17,7 @@ import com.yjjjwww.yunmarket.customer.repository.CustomerRepository;
 import com.yjjjwww.yunmarket.exception.CustomException;
 import com.yjjjwww.yunmarket.exception.ErrorCode;
 import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.product.repository.ProductRepository;
 import com.yjjjwww.yunmarket.seller.entity.Seller;
 import com.yjjjwww.yunmarket.transaction.entity.Ordered;
 import com.yjjjwww.yunmarket.transaction.entity.Transaction;
@@ -52,6 +53,9 @@ class OrderServiceImplTest {
   @Mock
   private TransactionRepository transactionRepository;
 
+  @Mock
+  private ProductRepository productRepository;
+
   @InjectMocks
   private OrderServiceImpl orderService;
 
@@ -78,6 +82,7 @@ class OrderServiceImplTest {
           .seller(seller)
           .price(1000 + i)
           .orderedCnt(0)
+          .quantity(100)
           .build();
 
       Cart cart = Cart.builder()


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 상품 상세정보를 조회하면 해당 IP가 조회한 상품을 데이터베이스에 저장한다.
- 최근 본 상품과 관련 인기 상품 불러오기를 요청하면 데이터베이스에서 상품을 조회하고 해당 카테고리에서 상품 주문 횟수가 많은 순으로 4개를 더 가져온다.
- ostman으로 API 테스트 완료했고, 테스트 코드로 올바른 응답이 나오는지 확인

**TO-BE**
- 상품 문의 기능

### 테스트
- [x] 테스트 코드
- [x] API 테스트 