### PR TITLE
feat : 상품 문의 기능 구현

### DIFF
--- a/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
+++ b/src/main/java/com/yjjjwww/yunmarket/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
   REVIEW_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "해당 주문의 리뷰가 이미 존재합니다."),
   REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "리뷰를 찾을 수 없습니다."),
   PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
+  QUESTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "문의를 찾을 수 없습니다."),
   CART_NOT_FOUND(HttpStatus.BAD_REQUEST, "장바구니를 찾을 수 없습니다."),
   ORDERED_NOT_FOUND(HttpStatus.BAD_REQUEST, "주문 정보를 찾을 수 없습니다."),
   TRANSACTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "주문 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/yjjjwww/yunmarket/question/controller/QuestionController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/controller/QuestionController.java
@@ -36,7 +36,7 @@ public class QuestionController {
     return ResponseEntity.ok(REGISTER_QUESTION_SUCCESS);
   }
 
-  @PostMapping
+  @PostMapping("/answer")
   @PreAuthorize("hasRole('SELLER')")
   public ResponseEntity<String> registerAnswer(
       @RequestHeader(name = HttpHeaders.AUTHORIZATION) String token,

--- a/src/main/java/com/yjjjwww/yunmarket/question/controller/QuestionController.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/controller/QuestionController.java
@@ -1,0 +1,56 @@
+package com.yjjjwww.yunmarket.question.controller;
+
+import com.yjjjwww.yunmarket.question.model.AnswerRegisterForm;
+import com.yjjjwww.yunmarket.question.model.QuestionDto;
+import com.yjjjwww.yunmarket.question.model.QuestionRegisterForm;
+import com.yjjjwww.yunmarket.question.service.QuestionService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/question")
+public class QuestionController {
+
+  private final QuestionService questionService;
+
+  private static final String REGISTER_QUESTION_SUCCESS = "문의 등록 완료";
+  private static final String REGISTER_ANSWER_SUCCESS = "답변 등록 완료";
+
+  @PostMapping
+  @PreAuthorize("hasRole('CUSTOMER')")
+  public ResponseEntity<String> registerQuestion(
+      @RequestHeader(name = HttpHeaders.AUTHORIZATION) String token,
+      @RequestBody QuestionRegisterForm form) {
+    questionService.registerQuestion(token, form.toServiceForm());
+    return ResponseEntity.ok(REGISTER_QUESTION_SUCCESS);
+  }
+
+  @PostMapping
+  @PreAuthorize("hasRole('SELLER')")
+  public ResponseEntity<String> registerAnswer(
+      @RequestHeader(name = HttpHeaders.AUTHORIZATION) String token,
+      @RequestBody AnswerRegisterForm form) {
+    questionService.registerAnswer(token, form.toServiceForm());
+    return ResponseEntity.ok(REGISTER_ANSWER_SUCCESS);
+  }
+
+  @GetMapping
+  public ResponseEntity<List<QuestionDto>> getQuestions(
+      @RequestParam("productId") Long productId,
+      @RequestParam("page") Integer page,
+      @RequestParam("size") Integer size
+  ) {
+    return ResponseEntity.ok(questionService.getQuestions(productId, page, size));
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/question/entity/Answer.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/entity/Answer.java
@@ -1,0 +1,43 @@
+
+package com.yjjjwww.yunmarket.question.entity;
+
+import com.yjjjwww.yunmarket.entity.BaseEntity;
+import com.yjjjwww.yunmarket.seller.entity.Seller;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+@Entity
+public class Answer extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "question_id")
+  @ToString.Exclude
+  private Question question;
+
+  @ManyToOne
+  @JoinColumn(name = "seller_id")
+  @ToString.Exclude
+  private Seller seller;
+
+  private String contents;
+  private boolean deletedYn;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/question/entity/Question.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/entity/Question.java
@@ -1,0 +1,58 @@
+
+package com.yjjjwww.yunmarket.question.entity;
+
+import com.yjjjwww.yunmarket.customer.entity.Customer;
+import com.yjjjwww.yunmarket.entity.BaseEntity;
+import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.seller.entity.Seller;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+@Entity
+public class Question extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "product_id")
+  @ToString.Exclude
+  private Product product;
+
+  @ManyToOne
+  @JoinColumn(name = "customer_id")
+  @ToString.Exclude
+  private Customer customer;
+
+  @ManyToOne
+  @JoinColumn(name = "seller_id")
+  @ToString.Exclude
+  private Seller seller;
+
+  @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
+  @ToString.Exclude
+  private List<Answer> answerList = new ArrayList<>();
+
+  private String contents;
+  private boolean deletedYn;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/question/model/AnswerDto.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/model/AnswerDto.java
@@ -1,0 +1,28 @@
+package com.yjjjwww.yunmarket.question.model;
+
+import com.yjjjwww.yunmarket.question.entity.Answer;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerDto {
+
+  private String sellerEmail;
+  private String contents;
+
+  public static List<AnswerDto> toDtoList(List<Answer> answerList) {
+    return answerList.stream()
+        .map(answer -> AnswerDto.builder()
+            .sellerEmail(answer.getSeller().getEmail())
+            .contents(answer.getContents())
+            .build())
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/question/model/AnswerRegisterForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/model/AnswerRegisterForm.java
@@ -1,0 +1,23 @@
+package com.yjjjwww.yunmarket.question.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerRegisterForm {
+
+  private Long questionId;
+  private String contents;
+
+  public AnswerRegisterServiceForm toServiceForm() {
+    return AnswerRegisterServiceForm.builder()
+        .questionId(questionId)
+        .contents(contents)
+        .build();
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/question/model/AnswerRegisterServiceForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/model/AnswerRegisterServiceForm.java
@@ -1,0 +1,16 @@
+package com.yjjjwww.yunmarket.question.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerRegisterServiceForm {
+
+  private Long questionId;
+  private String contents;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/question/model/QuestionDto.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/model/QuestionDto.java
@@ -1,0 +1,30 @@
+package com.yjjjwww.yunmarket.question.model;
+
+import com.yjjjwww.yunmarket.question.entity.Question;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionDto {
+
+  private String customerEmail;
+  private String contents;
+  private List<AnswerDto> answerDtoList;
+
+  public static List<QuestionDto> toDtoList(List<Question> questions) {
+    return questions.stream()
+        .map(question -> QuestionDto.builder()
+            .customerEmail(question.getCustomer().getEmail())
+            .contents(question.getContents())
+            .answerDtoList(AnswerDto.toDtoList(question.getAnswerList()))
+            .build())
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/question/model/QuestionRegisterForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/model/QuestionRegisterForm.java
@@ -1,0 +1,23 @@
+package com.yjjjwww.yunmarket.question.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionRegisterForm {
+
+  private Long productId;
+  private String contents;
+
+  public QuestionRegisterServiceForm toServiceForm() {
+    return QuestionRegisterServiceForm.builder()
+        .productId(productId)
+        .contents(contents)
+        .build();
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/question/model/QuestionRegisterServiceForm.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/model/QuestionRegisterServiceForm.java
@@ -1,0 +1,16 @@
+package com.yjjjwww.yunmarket.question.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionRegisterServiceForm {
+
+  private Long productId;
+  private String contents;
+}

--- a/src/main/java/com/yjjjwww/yunmarket/question/repository/AnswerRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/repository/AnswerRepository.java
@@ -1,0 +1,8 @@
+package com.yjjjwww.yunmarket.question.repository;
+
+import com.yjjjwww.yunmarket.question.entity.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+}

--- a/src/main/java/com/yjjjwww/yunmarket/question/repository/QuestionRepository.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/repository/QuestionRepository.java
@@ -1,0 +1,11 @@
+package com.yjjjwww.yunmarket.question.repository;
+
+import com.yjjjwww.yunmarket.question.entity.Question;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+  List<Question> findByProductId(Long productId, Pageable pageable);
+}

--- a/src/main/java/com/yjjjwww/yunmarket/question/service/QuestionService.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/service/QuestionService.java
@@ -1,0 +1,24 @@
+package com.yjjjwww.yunmarket.question.service;
+
+import com.yjjjwww.yunmarket.question.model.AnswerRegisterServiceForm;
+import com.yjjjwww.yunmarket.question.model.QuestionDto;
+import com.yjjjwww.yunmarket.question.model.QuestionRegisterServiceForm;
+import java.util.List;
+
+public interface QuestionService {
+
+  /**
+   * 문의 등록하기
+   */
+  void registerQuestion(String token, QuestionRegisterServiceForm form);
+
+  /**
+   * 문의 등록하기
+   */
+  void registerAnswer(String token, AnswerRegisterServiceForm form);
+
+  /**
+   * 문의 조회하기
+   */
+  List<QuestionDto> getQuestions(Long productId, Integer page, Integer size);
+}

--- a/src/main/java/com/yjjjwww/yunmarket/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/question/service/QuestionServiceImpl.java
@@ -1,0 +1,104 @@
+package com.yjjjwww.yunmarket.question.service;
+
+import com.yjjjwww.yunmarket.common.UserVo;
+import com.yjjjwww.yunmarket.config.JwtTokenProvider;
+import com.yjjjwww.yunmarket.customer.entity.Customer;
+import com.yjjjwww.yunmarket.customer.repository.CustomerRepository;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.product.repository.ProductRepository;
+import com.yjjjwww.yunmarket.question.entity.Answer;
+import com.yjjjwww.yunmarket.question.entity.Question;
+import com.yjjjwww.yunmarket.question.model.AnswerRegisterServiceForm;
+import com.yjjjwww.yunmarket.question.model.QuestionDto;
+import com.yjjjwww.yunmarket.question.model.QuestionRegisterServiceForm;
+import com.yjjjwww.yunmarket.question.repository.AnswerRepository;
+import com.yjjjwww.yunmarket.question.repository.QuestionRepository;
+import com.yjjjwww.yunmarket.seller.entity.Seller;
+import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class QuestionServiceImpl implements QuestionService{
+
+  private final JwtTokenProvider provider;
+  private final CustomerRepository customerRepository;
+  private final ProductRepository productRepository;
+  private final SellerRepository sellerRepository;
+  private final QuestionRepository questionRepository;
+  private final AnswerRepository answerRepository;
+
+  @Override
+  public void registerQuestion(String token, QuestionRegisterServiceForm form) {
+    Customer customer = getCustomerFromToken(token);
+
+    Product product = productRepository.findById(form.getProductId())
+        .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+    Seller seller = product.getSeller();
+
+    Question question = Question.builder()
+        .product(product)
+        .customer(customer)
+        .seller(seller)
+        .contents(form.getContents())
+        .deletedYn(false)
+        .build();
+
+    questionRepository.save(question);
+  }
+
+  @Override
+  public void registerAnswer(String token, AnswerRegisterServiceForm form) {
+    Seller seller = getSellerFromToken(token);
+
+    Question question = questionRepository.findById(form.getQuestionId())
+        .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
+
+    Answer answer = Answer.builder()
+        .question(question)
+        .seller(seller)
+        .contents(form.getContents())
+        .deletedYn(false)
+        .build();
+
+    answerRepository.save(answer);
+  }
+
+  @Override
+  public List<QuestionDto> getQuestions(Long productId, Integer page, Integer size) {
+    Pageable pageable = PageRequest.of(page - 1, size);
+
+    List<Question> questionList = questionRepository.findByProductId(productId, pageable);
+
+    if (questionList.size() == 0) {
+      throw new CustomException(ErrorCode.QUESTION_NOT_FOUND);
+    }
+
+    return QuestionDto.toDtoList(questionList);
+  }
+
+  private Customer getCustomerFromToken(String token) {
+    UserVo vo = provider.getUserVo(token);
+
+    Customer customer = customerRepository.findById(vo.getId())
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+    return customer;
+  }
+
+  private Seller getSellerFromToken(String token) {
+    UserVo vo = provider.getUserVo(token);
+
+    Seller seller = sellerRepository.findById(vo.getId())
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+    return seller;
+  }
+}

--- a/src/test/java/com/yjjjwww/yunmarket/question/controller/QuestionControllerTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/question/controller/QuestionControllerTest.java
@@ -1,0 +1,215 @@
+package com.yjjjwww.yunmarket.question.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yjjjwww.yunmarket.common.UserType;
+import com.yjjjwww.yunmarket.config.JwtTokenProvider;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.question.model.AnswerRegisterForm;
+import com.yjjjwww.yunmarket.question.model.QuestionRegisterForm;
+import com.yjjjwww.yunmarket.question.service.QuestionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class QuestionControllerTest {
+
+  @MockBean
+  private QuestionService questionService;
+
+  @MockBean
+  private JwtTokenProvider provider;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  @WithMockUser(roles = "CUSTOMER")
+  void registerQuestionSuccess() throws Exception {
+    //given
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.CUSTOMER);
+    QuestionRegisterForm form = QuestionRegisterForm.builder()
+        .productId(1L)
+        .contents("문의 내용")
+        .build();
+
+    //when
+    //then
+    mockMvc.perform(post("/question")
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @WithMockUser(roles = "SELLER")
+  void registerQuestionFail_SELLER_CANNOT_REGISTER() throws Exception {
+    //given
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.SELLER);
+    QuestionRegisterForm form = QuestionRegisterForm.builder()
+        .productId(1L)
+        .contents("문의 내용")
+        .build();
+
+    //when
+    //then
+    mockMvc.perform(post("/question")
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isForbidden())
+        .andDo(print());
+  }
+
+  @Test
+  @WithMockUser(roles = "CUSTOMER")
+  void registerQuestionFail_PRODUCT_NOT_FOUND() throws Exception {
+    //given
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.CUSTOMER);
+    QuestionRegisterForm form = QuestionRegisterForm.builder()
+        .productId(1L)
+        .contents("문의 내용")
+        .build();
+
+    doThrow(new CustomException(ErrorCode.PRODUCT_NOT_FOUND))
+        .when(questionService)
+        .registerQuestion(anyString(), any());
+
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/question")
+        .header("Authorization", "Bearer " + token)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("PRODUCT_NOT_FOUND", code);
+  }
+
+  @Test
+  @WithMockUser(roles = "SELLER")
+  void registerAnswerSuccess() throws Exception {
+    //given
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.SELLER);
+    AnswerRegisterForm form = AnswerRegisterForm.builder()
+        .questionId(1L)
+        .contents("답변 내용")
+        .build();
+
+    //when
+    //then
+    mockMvc.perform(post("/question/answer")
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @WithMockUser(roles = "CUSTOMER")
+  void registerAnswerFail_CUSTOMER_CANNOT_REGISTER() throws Exception {
+    //given
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.CUSTOMER);
+    AnswerRegisterForm form = AnswerRegisterForm.builder()
+        .questionId(1L)
+        .contents("답변 내용")
+        .build();
+
+    //when
+    //then
+    mockMvc.perform(post("/question/answer")
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isForbidden())
+        .andDo(print());
+  }
+
+  @Test
+  @WithMockUser(roles = "SELLER")
+  void registerAnswerFail_QUESTION_NOT_FOUND() throws Exception {
+    //given
+    String token = provider.createToken("yjjjwww@naver.com", 1L, UserType.SELLER);
+    AnswerRegisterForm form = AnswerRegisterForm.builder()
+        .questionId(1L)
+        .contents("답변 내용")
+        .build();
+
+    doThrow(new CustomException(ErrorCode.QUESTION_NOT_FOUND))
+        .when(questionService)
+        .registerAnswer(anyString(), any());
+
+    //when
+    //then
+    ResultActions result = mockMvc.perform(post("/question/answer")
+        .header("Authorization", "Bearer " + token)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(form)));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("QUESTION_NOT_FOUND", code);
+  }
+
+  @Test
+  void getQuestionsSuccess() throws Exception {
+    //given
+    //when
+    //then
+    mockMvc.perform(get("/question?productId=1&page=0&size=5"))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  void getQuestionsFail_QUESTION_NOT_FOUND() throws Exception {
+    //given
+    doThrow(new CustomException(ErrorCode.QUESTION_NOT_FOUND))
+        .when(questionService)
+        .getQuestions(anyLong(), anyInt(), anyInt());
+
+    //when
+    //then
+    ResultActions result = mockMvc.perform(get("/question?productId=1&page=0&size=5"));
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+    String responseBody = result.andReturn().getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String code = responseJson.get("code").asText();
+
+    assertEquals("QUESTION_NOT_FOUND", code);
+  }
+}

--- a/src/test/java/com/yjjjwww/yunmarket/question/service/QuestionServiceImplTest.java
+++ b/src/test/java/com/yjjjwww/yunmarket/question/service/QuestionServiceImplTest.java
@@ -1,0 +1,228 @@
+package com.yjjjwww.yunmarket.question.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.yjjjwww.yunmarket.common.UserVo;
+import com.yjjjwww.yunmarket.config.JwtTokenProvider;
+import com.yjjjwww.yunmarket.customer.entity.Customer;
+import com.yjjjwww.yunmarket.customer.repository.CustomerRepository;
+import com.yjjjwww.yunmarket.exception.CustomException;
+import com.yjjjwww.yunmarket.exception.ErrorCode;
+import com.yjjjwww.yunmarket.product.entity.Category;
+import com.yjjjwww.yunmarket.product.entity.Product;
+import com.yjjjwww.yunmarket.product.repository.ProductRepository;
+import com.yjjjwww.yunmarket.question.entity.Answer;
+import com.yjjjwww.yunmarket.question.entity.Question;
+import com.yjjjwww.yunmarket.question.model.AnswerRegisterServiceForm;
+import com.yjjjwww.yunmarket.question.model.QuestionDto;
+import com.yjjjwww.yunmarket.question.model.QuestionRegisterServiceForm;
+import com.yjjjwww.yunmarket.question.repository.AnswerRepository;
+import com.yjjjwww.yunmarket.question.repository.QuestionRepository;
+import com.yjjjwww.yunmarket.seller.entity.Seller;
+import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class QuestionServiceImplTest {
+
+  @Mock
+  private JwtTokenProvider provider;
+
+  @Mock
+  private CustomerRepository customerRepository;
+
+  @Mock
+  private SellerRepository sellerRepository;
+
+  @Mock
+  private ProductRepository productRepository;
+
+  @Mock
+  private QuestionRepository questionRepository;
+
+  @Mock
+  private AnswerRepository answerRepository;
+
+  @InjectMocks
+  private QuestionServiceImpl questionService;
+
+  @Test
+  void registerQuestionSuccess() {
+    //given
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    Customer customer = Customer.builder()
+        .id(1L)
+        .build();
+    given(customerRepository.findById(anyLong()))
+        .willReturn(Optional.ofNullable(customer));
+
+    QuestionRegisterServiceForm form = QuestionRegisterServiceForm.builder()
+        .productId(1L)
+        .contents("문의 내용")
+        .build();
+
+    Product product = Product.builder()
+        .id(1L)
+        .price(4000)
+        .name("상품 이름")
+        .image("이미지")
+        .quantity(1000)
+        .category(Category.builder().build())
+        .description("상품 설명")
+        .orderedCnt(1)
+        .deletedYn(false)
+        .seller(Seller.builder()
+            .id(1L)
+            .build())
+        .build();
+
+    given(productRepository.findById(anyLong()))
+        .willReturn(Optional.ofNullable(product));
+
+    //when
+    questionService.registerQuestion("token", form);
+
+    //then
+    verify(questionRepository, times(1)).save(any(Question.class));
+  }
+
+  @Test
+  void registerQuestionFail_PRODUCT_NOT_FOUND() {
+    //given
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    Customer customer = Customer.builder()
+        .id(1L)
+        .build();
+    given(customerRepository.findById(anyLong()))
+        .willReturn(Optional.ofNullable(customer));
+
+    QuestionRegisterServiceForm form = QuestionRegisterServiceForm.builder()
+        .productId(1L)
+        .contents("문의 내용")
+        .build();
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> questionService.registerQuestion("token", form));
+
+    //then
+    assertEquals(ErrorCode.PRODUCT_NOT_FOUND, exception.getErrorCode());
+  }
+
+  @Test
+  void registerAnswerSuccess() {
+    //given
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    Seller seller = Seller.builder()
+        .id(1L)
+        .build();
+    given(sellerRepository.findById(anyLong()))
+        .willReturn(Optional.ofNullable(seller));
+
+    AnswerRegisterServiceForm form = AnswerRegisterServiceForm.builder()
+        .questionId(1L)
+        .contents("답변 내용")
+        .build();
+
+    Question question = Question.builder()
+        .id(1L)
+        .build();
+
+    given(questionRepository.findById(anyLong()))
+        .willReturn(Optional.ofNullable(question));
+
+    //when
+    questionService.registerAnswer("token", form);
+
+    //then
+    verify(answerRepository, times(1)).save(any(Answer.class));
+  }
+
+  @Test
+  void registerAnswerFail_QUESTION_NOT_FOUND() {
+    //given
+    given(provider.getUserVo(anyString()))
+        .willReturn(new UserVo(1L, "yjjjwww@naver.com"));
+
+    Seller seller = Seller.builder()
+        .id(1L)
+        .build();
+    given(sellerRepository.findById(anyLong()))
+        .willReturn(Optional.ofNullable(seller));
+
+    AnswerRegisterServiceForm form = AnswerRegisterServiceForm.builder()
+        .questionId(1L)
+        .contents("답변 내용")
+        .build();
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> questionService.registerAnswer("token", form));
+
+    //then
+    assertEquals(ErrorCode.QUESTION_NOT_FOUND, exception.getErrorCode());
+  }
+
+  @Test
+  void getQuestionsSuccess() {
+    //given
+    List<Question> questionList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      List<Answer> answerList = new ArrayList<>();
+
+      Question question = Question.builder()
+          .id((long) i)
+          .customer(Customer.builder()
+              .email("이메일")
+              .build())
+          .contents("질문 내용")
+          .answerList(answerList)
+          .build();
+      questionList.add(question);
+    }
+
+    given(questionRepository.findByProductId(anyLong(), any()))
+        .willReturn(questionList);
+
+    //when
+    List<QuestionDto> questionDtos = questionService.getQuestions(1L, 1, 5);
+
+    //then
+    assertEquals(3, questionDtos.size());
+  }
+
+  @Test
+  void getQuestionsFail_QUESTION_NOT_FOUND() {
+    //given
+    List<Question> questionList = new ArrayList<>();
+
+    given(questionRepository.findByProductId(anyLong(), any()))
+        .willReturn(questionList);
+
+    CustomException exception = assertThrows(CustomException.class,
+        () -> questionService.getQuestions(1L, 1, 5));
+
+    //then
+    assertEquals(ErrorCode.QUESTION_NOT_FOUND, exception.getErrorCode());
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- customer는 상품에 대한 문의를 등록, seller는 자신이 판매하는 상품에 문의가 달리면 답변을 할 수 있음.
- 상품에 대한 문의를 조회하면 문의와 문의에 대한 답변 목록들이 조회됨.
- postman으로 API 테스트 완료했고, 테스트 코드로 올바른 응답이 나오는지 확인

**TO-BE**
- 상품 조회하기 Redis 캐싱 처리

### 테스트
- [x] 테스트 코드
- [x] API 테스트 