### PR TITLE
feat : 상품 조회하기 캐싱 처리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/yjjjwww/yunmarket/YunmarketApplication.java
+++ b/src/main/java/com/yjjjwww/yunmarket/YunmarketApplication.java
@@ -2,8 +2,10 @@ package com.yjjjwww.yunmarket;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class YunmarketApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/yjjjwww/yunmarket/config/RedisConfig.java
+++ b/src/main/java/com/yjjjwww/yunmarket/config/RedisConfig.java
@@ -1,0 +1,51 @@
+package com.yjjjwww.yunmarket.config;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.redis.host}")
+  private String host;
+
+  @Value("${spring.redis.port}")
+  private int port;
+
+  @Value("${spring.redis.expire}")
+  private int expire;
+
+  @Bean
+  public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+    RedisCacheConfiguration conf = RedisCacheConfiguration.defaultCacheConfig()
+        .serializeKeysWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+        .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+            new GenericJackson2JsonRedisSerializer()))
+        .entryTtl(Duration.ofSeconds(expire));
+
+    return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
+        .cacheDefaults(conf).build();
+  }
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration conf = new RedisStandaloneConfiguration();
+    conf.setHostName(this.host);
+    conf.setPort(this.port);
+    return new LettuceConnectionFactory(conf);
+  }
+}

--- a/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/product/service/ProductServiceImpl.java
@@ -19,6 +19,8 @@ import com.yjjjwww.yunmarket.seller.repository.SellerRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -37,6 +39,7 @@ public class ProductServiceImpl implements ProductService {
   private final ProductViewHistoryRepository productViewHistoryRepository;
 
   @Override
+  @CacheEvict(value = "product", allEntries = true)
   public void register(String token, ProductRegisterServiceForm form) {
     if (isStringEmpty(form.getName()) || form.getPrice() <= 0 || isStringEmpty(
         form.getDescription()) || form.getQuantity() <= 0) {
@@ -68,6 +71,7 @@ public class ProductServiceImpl implements ProductService {
   }
 
   @Override
+  @Cacheable(key = "#pageable", value = "product")
   public List<ProductInfo> getProducts(Pageable pageable) {
     Page<Product> products = productRepository.findAll(pageable);
 
@@ -84,6 +88,7 @@ public class ProductServiceImpl implements ProductService {
   }
 
   @Override
+  @Cacheable(key = "#id", value = "productInfo")
   public ProductInfo getProductInfo(Long id, String userIp) {
     Product product = productRepository.findById(id)
         .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));

--- a/src/main/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImpl.java
+++ b/src/main/java/com/yjjjwww/yunmarket/transaction/service/OrderServiceImpl.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +38,7 @@ public class OrderServiceImpl implements OrderService {
 
   @Override
   @Transactional
+  @CacheEvict(value = "productInfo", allEntries = true)
   public void orderItems(String token, Integer point) {
     Customer customer = getCustomerFromToken(token);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,4 +9,8 @@ spring.data.elasticsearch.cluster-name=elasticsearch
 spring.data.elasticsearch.cluster-nodes=localhost:9200
 spring.main.allow-bean-definition-overriding=true
 
+spring.redis.host=localhost
+spring.redis.port=6379
+spring.redis.expire=120
+
 jwt.secret.key=yunmarket1234


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 상품 목록 조회하기 pageable를 key 값으로 redis에 저장
- 상품 상세 정보 보기 product Id를 key 값으로 redis에 저장
- ttl은 120초로 설정
- 상품 등록시 상품 목록 조회하기 CacheEvict, 상품 주문시 상품 상세 정보 보기 CacheEvict
- postman으로 api 테스트 완료했고, RedisInsight로 데이터베이스 확인 했습니다.

**TO-BE**
- 배포하기

### 테스트
- [x] 테스트 코드
- [x] API 테스트 